### PR TITLE
Fix: Stale job index issues. Version updated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,9 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rrq"
-version = "0.9.0"
+version = "0.9.1"
 authors = [{ name = "Mazdak Rezvani", email = "mazdak@me.com" }]
-description = "RRQ is a library for creating reliable job queues using Rust, Redis and asyncio"
+description = "RRQ is a library for creating reliable job queues using Rust, Redis. with language-agnostic producers and workers."
 readme = "README.md"
 requires-python = ">=3.11"
 classifiers = [

--- a/rrq-rs/Cargo.lock
+++ b/rrq-rs/Cargo.lock
@@ -1240,7 +1240,7 @@ dependencies = [
 
 [[package]]
 name = "rrq"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "rrq-executor"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -1284,7 +1284,7 @@ dependencies = [
 
 [[package]]
 name = "rrq-producer"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1296,7 +1296,7 @@ dependencies = [
 
 [[package]]
 name = "rrq-protocol"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "serde",

--- a/rrq-rs/rrq-executor/Cargo.toml
+++ b/rrq-rs/rrq-executor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrq-executor"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "RRQ Unix socket executor runtime for Rust."

--- a/rrq-rs/rrq-orchestrator/Cargo.toml
+++ b/rrq-rs/rrq-orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrq"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "RRQ orchestrator CLI and worker runtime."

--- a/rrq-rs/rrq-producer/Cargo.toml
+++ b/rrq-rs/rrq-producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrq-producer"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "RRQ producer client for enqueuing jobs into Redis."

--- a/rrq-rs/rrq-protocol/Cargo.toml
+++ b/rrq-rs/rrq-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrq-protocol"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Shared RRQ executor protocol types."

--- a/uv.lock
+++ b/uv.lock
@@ -573,7 +573,7 @@ hiredis = [
 
 [[package]]
 name = "rrq"
-version = "0.9.0"
+version = "0.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches executor runtime concurrency/cleanup paths; incorrect locking or cleanup could cause missed cancellations or task leaks, though changes are localized and covered by a new test.
> 
> **Overview**
> Fixes executor connection teardown so **in-flight tracking is fully cleaned up**: per-connection request IDs are tracked in a shared `HashSet`, and on socket close any remaining tasks are aborted *and* their `job_index` entries are removed to prevent stale job→request mappings. Adds a regression test (`connection_teardown_clears_tracking_maps`) to assert both `in_flight` and `job_index` are empty after disconnect.
> 
> Bumps RRQ versions to `0.9.1` across Python (`pyproject.toml`, `uv.lock`) and Rust crates (`Cargo.toml`/`Cargo.lock`), and updates the Python package description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 00d114f6ffddb7116826da872d5dbdae46ff7f8f. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->