### PR TITLE
Add rrq-ts TypeScript producer and executor runtime (Node/Bun)

### DIFF
--- a/docs/EXECUTOR_PROTOCOL.md
+++ b/docs/EXECUTOR_PROTOCOL.md
@@ -182,6 +182,7 @@ Example: `rust#send_email`. The orchestrator strips the prefix and sends only
 
 ## Reference Implementations
 - Python: `reference/python/socket_executor.py`
+- TypeScript: `reference/typescript/executor_runtime.ts`
 - Rust protocol types: `rrq-rs/rrq-protocol`
 - Rust executor: `rrq-rs/rrq-executor` (see
   `rrq-rs/rrq-executor/examples/socket_executor.rs`)

--- a/reference/typescript/executor_runtime.ts
+++ b/reference/typescript/executor_runtime.ts
@@ -1,0 +1,531 @@
+import fs from "node:fs";
+import net from "node:net";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+export const ENV_EXECUTOR_SOCKET = "RRQ_EXECUTOR_SOCKET";
+export const ENV_EXECUTOR_TCP_SOCKET = "RRQ_EXECUTOR_TCP_SOCKET";
+export const PROTOCOL_VERSION = "1";
+const MAX_FRAME_LEN = 16 * 1024 * 1024;
+
+export type OutcomeStatus = "success" | "retry" | "timeout" | "error";
+
+export interface ExecutionContext {
+  job_id: string;
+  attempt: number;
+  enqueue_time: string;
+  queue_name: string;
+  deadline?: string | null;
+  trace_context?: Record<string, string> | null;
+  worker_id?: string | null;
+}
+
+export interface ExecutionRequest {
+  protocol_version: string;
+  request_id: string;
+  job_id: string;
+  function_name: string;
+  args: unknown[];
+  kwargs: Record<string, unknown>;
+  context: ExecutionContext;
+}
+
+export interface ExecutionError {
+  message: string;
+  type?: string | null;
+  code?: string | null;
+  details?: Record<string, unknown> | null;
+}
+
+export interface ExecutionOutcome {
+  job_id: string;
+  request_id: string | null;
+  status: OutcomeStatus;
+  result?: unknown | null;
+  error?: ExecutionError | null;
+  retry_after_seconds?: number | null;
+}
+
+export interface CancelRequest {
+  protocol_version: string;
+  job_id: string;
+  request_id?: string | null;
+  hard_kill?: boolean;
+}
+
+type ExecutorMessage =
+  | { type: "request"; payload: ExecutionRequest }
+  | { type: "response"; payload: ExecutionOutcome }
+  | { type: "cancel"; payload: CancelRequest };
+
+export type Handler = (
+  request: ExecutionRequest,
+  signal: AbortSignal,
+) => Promise<ExecutionOutcome | unknown> | ExecutionOutcome | unknown;
+
+export class Registry {
+  private handlers = new Map<string, Handler>();
+
+  register(name: string, handler: Handler): void {
+    this.handlers.set(name, handler);
+  }
+
+  async execute(
+    request: ExecutionRequest,
+    signal: AbortSignal,
+  ): Promise<ExecutionOutcome> {
+    const handler = this.handlers.get(request.function_name);
+    if (!handler) {
+      return errorOutcome(request, "handler_not_found", "Handler not found");
+    }
+
+    try {
+      const result = await handler(request, signal);
+      if (isExecutionOutcome(result)) {
+        return result;
+      }
+      return {
+        job_id: request.job_id,
+        request_id: request.request_id,
+        status: "success",
+        result,
+      };
+    } catch (error) {
+      if (isAbortError(error)) {
+        return errorOutcome(request, "cancelled", "Job cancelled");
+      }
+      return errorOutcome(request, undefined, asErrorMessage(error));
+    }
+  }
+}
+
+interface InFlightTask {
+  controller: AbortController;
+  respond: (outcome: ExecutionOutcome) => Promise<void>;
+  job_id: string;
+}
+
+export class ExecutorRuntime {
+  private registry: Registry;
+  private inFlight = new Map<string, InFlightTask>();
+  private jobIndex = new Map<string, string>();
+
+  constructor(registry: Registry) {
+    this.registry = registry;
+  }
+
+  async runFromEnv(): Promise<void> {
+    const socketPath = process.env[ENV_EXECUTOR_SOCKET];
+    const tcpSocket = process.env[ENV_EXECUTOR_TCP_SOCKET];
+    if (socketPath && tcpSocket) {
+      throw new Error("Provide only one of RRQ_EXECUTOR_SOCKET or RRQ_EXECUTOR_TCP_SOCKET");
+    }
+    if (tcpSocket) {
+      const address = parseTcpSocket(tcpSocket);
+      await this.runTcp(address.host, address.port);
+      return;
+    }
+    if (!socketPath) {
+      throw new Error(
+        `${ENV_EXECUTOR_SOCKET} or ${ENV_EXECUTOR_TCP_SOCKET} must be set`,
+      );
+    }
+    await this.runSocket(socketPath);
+  }
+
+  async runSocket(socketPath: string): Promise<void> {
+    await fs.promises.mkdir(path.dirname(socketPath), { recursive: true });
+    if (fs.existsSync(socketPath)) {
+      await fs.promises.unlink(socketPath);
+    }
+    await this.runServer({ path: socketPath });
+  }
+
+  async runTcp(host: string, port: number): Promise<void> {
+    await this.runServer({ host, port });
+  }
+
+  private async runServer(options: net.ListenOptions): Promise<void> {
+    const server = net.createServer((socket) => this.handleConnection(socket));
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(options, resolve);
+    });
+  }
+
+  private handleConnection(socket: net.Socket): void {
+    const parser = new FrameParser();
+    const activeRequests = new Set<string>();
+    let writeChain = Promise.resolve();
+
+    const enqueueWrite = (message: ExecutorMessage): Promise<void> => {
+      writeChain = writeChain.then(() => writeFrame(socket, message));
+      return writeChain;
+    };
+
+    const respond = async (outcome: ExecutionOutcome): Promise<void> => {
+      await enqueueWrite({ type: "response", payload: outcome });
+    };
+
+    const cleanupRequest = (requestId: string, jobId: string): void => {
+      this.inFlight.delete(requestId);
+      this.jobIndex.delete(jobId);
+      activeRequests.delete(requestId);
+    };
+
+    socket.on("data", (chunk) => {
+      const messages = parser.push(chunk);
+      for (const message of messages) {
+        if (message.type === "request") {
+          const request = message.payload;
+          if (request.protocol_version !== PROTOCOL_VERSION) {
+            void respond(
+              errorOutcome(
+                request,
+                "protocol",
+                "Unsupported protocol version",
+              ),
+            );
+            continue;
+          }
+
+          const controller = new AbortController();
+          const requestId = request.request_id;
+          const jobId = request.job_id;
+
+          this.inFlight.set(requestId, {
+            controller,
+            respond,
+            job_id: jobId,
+          });
+          this.jobIndex.set(jobId, requestId);
+          activeRequests.add(requestId);
+
+          void this.executeWithDeadline(request, controller.signal)
+            .then(async (outcome) => {
+              await respond(outcome);
+              cleanupRequest(requestId, jobId);
+            })
+            .catch(async (error) => {
+              await respond(errorOutcome(request, undefined, asErrorMessage(error)));
+              cleanupRequest(requestId, jobId);
+            });
+        } else if (message.type === "cancel") {
+          this.handleCancel(message.payload);
+        } else {
+          void respond({
+            job_id: "unknown",
+            request_id: null,
+            status: "error",
+            error: { message: "Unexpected response message" },
+          });
+        }
+      }
+    });
+
+    socket.on("close", () => {
+      for (const requestId of activeRequests) {
+        const task = this.inFlight.get(requestId);
+        if (task) {
+          task.controller.abort();
+          this.jobIndex.delete(task.job_id);
+          this.inFlight.delete(requestId);
+        }
+      }
+    });
+
+    socket.on("error", (error) => {
+      console.error("executor connection error:", error);
+      socket.destroy();
+    });
+  }
+
+  private async executeWithDeadline(
+    request: ExecutionRequest,
+    signal: AbortSignal,
+  ): Promise<ExecutionOutcome> {
+    const deadline = request.context.deadline;
+    if (!deadline) {
+      return this.registry.execute(request, signal);
+    }
+
+    const deadlineDate = new Date(deadline);
+    if (Number.isNaN(deadlineDate.getTime())) {
+      return errorOutcome(request, "deadline", "Invalid deadline timestamp");
+    }
+    const remainingMs = deadlineDate.getTime() - Date.now();
+    if (remainingMs <= 0) {
+      return timeoutOutcome(request, "Job deadline exceeded");
+    }
+
+    try {
+      return await withTimeout(
+        this.registry.execute(request, signal),
+        remainingMs,
+        signal,
+      );
+    } catch (error) {
+      if (isAbortError(error)) {
+        return errorOutcome(request, "cancelled", "Job cancelled");
+      }
+      if (error instanceof TimeoutError) {
+        return timeoutOutcome(request, "Job execution timed out");
+      }
+      return errorOutcome(request, undefined, asErrorMessage(error));
+    }
+  }
+
+  private handleCancel(payload: CancelRequest): void {
+    if (payload.protocol_version !== PROTOCOL_VERSION) {
+      return;
+    }
+    const requestId = payload.request_id ?? this.jobIndex.get(payload.job_id);
+    if (!requestId) {
+      return;
+    }
+    const task = this.inFlight.get(requestId);
+    if (!task) {
+      return;
+    }
+    task.controller.abort();
+    void task.respond({
+      job_id: payload.job_id,
+      request_id: requestId,
+      status: "error",
+      error: { message: "Job cancelled", type: "cancelled" },
+    });
+    this.inFlight.delete(requestId);
+    this.jobIndex.delete(task.job_id);
+  }
+}
+
+export function parseTcpSocket(value: string): { host: string; port: number } {
+  const raw = value.trim();
+  if (!raw) {
+    throw new Error("executor tcp_socket cannot be empty");
+  }
+
+  let host: string;
+  let portPart: string;
+  if (raw.startsWith("[")) {
+    const closing = raw.indexOf("]:");
+    if (closing === -1) {
+      throw new Error("executor tcp_socket must be in [host]:port format");
+    }
+    host = raw.slice(1, closing);
+    portPart = raw.slice(closing + 2);
+  } else {
+    const lastColon = raw.lastIndexOf(":");
+    if (lastColon === -1) {
+      throw new Error("executor tcp_socket must be in host:port format");
+    }
+    host = raw.slice(0, lastColon);
+    portPart = raw.slice(lastColon + 1);
+    if (!host) {
+      throw new Error("executor tcp_socket host cannot be empty");
+    }
+  }
+
+  const port = Number.parseInt(portPart, 10);
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid executor tcp_socket port: ${portPart}`);
+  }
+
+  if (host === "localhost") {
+    return { host: "127.0.0.1", port };
+  }
+  if (!net.isIP(host)) {
+    throw new Error(`Invalid executor tcp_socket host: ${host}`);
+  }
+  if (!isLoopback(host)) {
+    throw new Error("executor tcp_socket host must be localhost");
+  }
+  return { host, port };
+}
+
+class FrameParser {
+  private buffer = Buffer.alloc(0);
+
+  push(chunk: Buffer): ExecutorMessage[] {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    const messages: ExecutorMessage[] = [];
+    while (this.buffer.length >= 4) {
+      const length = this.buffer.readUInt32BE(0);
+      if (length === 0) {
+        throw new Error("executor message payload cannot be empty");
+      }
+      if (length > MAX_FRAME_LEN) {
+        throw new Error("executor message payload too large");
+      }
+      if (this.buffer.length < 4 + length) {
+        break;
+      }
+      const payload = this.buffer.subarray(4, 4 + length);
+      this.buffer = this.buffer.subarray(4 + length);
+      const decoded = JSON.parse(payload.toString("utf-8")) as ExecutorMessage;
+      messages.push(decoded);
+    }
+    return messages;
+  }
+}
+
+async function writeFrame(
+  socket: net.Socket,
+  message: ExecutorMessage,
+): Promise<void> {
+  const payload = Buffer.from(JSON.stringify(message));
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(payload.length, 0);
+  await new Promise<void>((resolve, reject) => {
+    socket.write(Buffer.concat([header, payload]), (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function errorOutcome(
+  request: ExecutionRequest,
+  type: string | undefined,
+  message: string,
+): ExecutionOutcome {
+  return {
+    job_id: request.job_id,
+    request_id: request.request_id,
+    status: "error",
+    error: {
+      message,
+      type: type ?? null,
+    },
+  };
+}
+
+function timeoutOutcome(request: ExecutionRequest, message: string): ExecutionOutcome {
+  return {
+    job_id: request.job_id,
+    request_id: request.request_id,
+    status: "timeout",
+    error: {
+      message,
+      type: "timeout",
+    },
+  };
+}
+
+function isExecutionOutcome(value: unknown): value is ExecutionOutcome {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as ExecutionOutcome;
+  return (
+    typeof candidate.status === "string" &&
+    typeof candidate.job_id === "string" &&
+    "request_id" in candidate
+  );
+}
+
+function asErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function isAbortError(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
+  return (
+    error instanceof Error &&
+    (error.name === "AbortError" || error.message === "Job cancelled")
+  );
+}
+
+class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeoutError";
+  }
+}
+
+function createAbortError(): Error {
+  if (typeof globalThis.DOMException === "function") {
+    return new globalThis.DOMException("Job cancelled", "AbortError");
+  }
+  const fallback = new Error("Job cancelled");
+  fallback.name = "AbortError";
+  return fallback;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  return new Promise<T>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(createAbortError());
+      return;
+    }
+
+    const onAbort = () => {
+      cleanup();
+      reject(createAbortError());
+    };
+
+    const cleanup = () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      signal.removeEventListener("abort", onAbort);
+    };
+
+    signal.addEventListener("abort", onAbort);
+    timer = setTimeout(() => {
+      cleanup();
+      reject(new TimeoutError("Job execution timed out"));
+    }, timeoutMs);
+
+    promise
+      .then((value) => {
+        cleanup();
+        resolve(value);
+      })
+      .catch((error) => {
+        cleanup();
+        reject(error);
+      });
+  });
+}
+
+function isLoopback(host: string): boolean {
+  if (net.isIP(host) === 4) {
+    return host.startsWith("127.");
+  }
+  return host === "::1";
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const registry = new Registry();
+  registry.register("echo", (request) => ({
+    job_id: request.job_id,
+    request_id: request.request_id,
+    status: "success",
+    result: { job_id: request.job_id },
+  }));
+
+  const runtime = new ExecutorRuntime(registry);
+  runtime
+    .runFromEnv()
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    })
+    .finally(() => {
+      process.exitCode = process.exitCode ?? 0;
+    });
+}

--- a/rrq-ts/LICENSE
+++ b/rrq-ts/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2025 Mazdak Rezvani
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/rrq-ts/README.md
+++ b/rrq-ts/README.md
@@ -1,0 +1,95 @@
+# RRQ TypeScript (Producer + Executor)
+
+TypeScript/JavaScript package for RRQ (Reliable Redis Queue). Includes:
+
+- **Producer** client for enqueuing jobs into RRQ.
+- **Executor runtime** to run job handlers over the RRQ socket protocol.
+
+Designed to work with **Node.js** and **Bun**.
+
+## Installation
+
+```bash
+npm install rrq-ts
+```
+
+## Producer usage
+
+```ts
+import { RRQClient } from "rrq-ts";
+
+const client = new RRQClient({
+  redisDsn: "redis://localhost:6379/0",
+});
+
+const jobId = await client.enqueue("send_email", {
+  args: ["user@example.com"],
+  kwargs: { template: "welcome" },
+  queueName: "rrq:queue:default",
+  maxRetries: 5,
+});
+
+console.log("enqueued", jobId);
+await client.close();
+```
+
+### Producer options
+
+```ts
+interface EnqueueOptions {
+  args?: unknown[];
+  kwargs?: Record<string, unknown>;
+  queueName?: string;
+  jobId?: string;
+  uniqueKey?: string;
+  maxRetries?: number;
+  jobTimeoutSeconds?: number;
+  resultTtlSeconds?: number;
+  deferUntil?: Date;
+  deferBySeconds?: number;
+  traceContext?: Record<string, string> | null;
+}
+```
+
+## Executor runtime usage
+
+```ts
+import { ExecutorRuntime, Registry } from "rrq-ts";
+
+const registry = new Registry();
+registry.register("send_email", async (request) => {
+  // handle request.args / request.kwargs
+  return {
+    job_id: request.job_id,
+    request_id: request.request_id,
+    status: "success",
+    result: { ok: true },
+  };
+});
+
+const runtime = new ExecutorRuntime(registry);
+await runtime.runFromEnv();
+```
+
+The orchestrator sets `RRQ_EXECUTOR_SOCKET` or `RRQ_EXECUTOR_TCP_SOCKET` when
+launching executors. You can also run the runtime directly:
+
+```bash
+RRQ_EXECUTOR_SOCKET=/tmp/rrq-executor.sock node dist/executor_runtime.js
+```
+
+## Build
+
+```bash
+npm run build
+```
+
+## Notes
+
+- Producer writes job hashes and queue entries compatible with RRQ's Python/Rust
+  orchestrator.
+- The executor implements the RRQ v1 socket protocol.
+
+## License
+
+MIT

--- a/rrq-ts/package.json
+++ b/rrq-ts/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "rrq-ts",
+  "version": "0.1.0",
+  "description": "RRQ TypeScript producer and executor runtime.",
+  "license": "MIT",
+  "author": "RRQ Contributors",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./producer": {
+      "types": "./dist/producer.d.ts",
+      "default": "./dist/producer.js"
+    },
+    "./executor": {
+      "types": "./dist/executor_runtime.d.ts",
+      "default": "./dist/executor_runtime.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "ioredis": "^5.4.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3"
+  }
+}

--- a/rrq-ts/src/constants.ts
+++ b/rrq-ts/src/constants.ts
@@ -1,0 +1,11 @@
+export const JOB_KEY_PREFIX = "rrq:job:";
+export const QUEUE_KEY_PREFIX = "rrq:queue:";
+export const DLQ_KEY_PREFIX = "rrq:dlq:";
+export const UNIQUE_JOB_LOCK_PREFIX = "rrq:lock:unique:";
+
+export const DEFAULT_QUEUE_NAME = "rrq:queue:default";
+export const DEFAULT_DLQ_NAME = "rrq:dlq:default";
+export const DEFAULT_MAX_RETRIES = 5;
+export const DEFAULT_JOB_TIMEOUT_SECONDS = 300;
+export const DEFAULT_RESULT_TTL_SECONDS = 24 * 60 * 60;
+export const DEFAULT_UNIQUE_JOB_LOCK_TTL_SECONDS = 6 * 60 * 60;

--- a/rrq-ts/src/executor_runtime.ts
+++ b/rrq-ts/src/executor_runtime.ts
@@ -1,0 +1,531 @@
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const ENV_EXECUTOR_SOCKET = "RRQ_EXECUTOR_SOCKET";
+export const ENV_EXECUTOR_TCP_SOCKET = "RRQ_EXECUTOR_TCP_SOCKET";
+export const PROTOCOL_VERSION = "1";
+const MAX_FRAME_LEN = 16 * 1024 * 1024;
+
+export type OutcomeStatus = "success" | "retry" | "timeout" | "error";
+
+export interface ExecutionContext {
+  job_id: string;
+  attempt: number;
+  enqueue_time: string;
+  queue_name: string;
+  deadline?: string | null;
+  trace_context?: Record<string, string> | null;
+  worker_id?: string | null;
+}
+
+export interface ExecutionRequest {
+  protocol_version: string;
+  request_id: string;
+  job_id: string;
+  function_name: string;
+  args: unknown[];
+  kwargs: Record<string, unknown>;
+  context: ExecutionContext;
+}
+
+export interface ExecutionError {
+  message: string;
+  type?: string | null;
+  code?: string | null;
+  details?: Record<string, unknown> | null;
+}
+
+export interface ExecutionOutcome {
+  job_id: string;
+  request_id: string | null;
+  status: OutcomeStatus;
+  result?: unknown | null;
+  error?: ExecutionError | null;
+  retry_after_seconds?: number | null;
+}
+
+export interface CancelRequest {
+  protocol_version: string;
+  job_id: string;
+  request_id?: string | null;
+  hard_kill?: boolean;
+}
+
+type ExecutorMessage =
+  | { type: "request"; payload: ExecutionRequest }
+  | { type: "response"; payload: ExecutionOutcome }
+  | { type: "cancel"; payload: CancelRequest };
+
+export type Handler = (
+  request: ExecutionRequest,
+  signal: AbortSignal,
+) => Promise<ExecutionOutcome | unknown> | ExecutionOutcome | unknown;
+
+export class Registry {
+  private handlers = new Map<string, Handler>();
+
+  register(name: string, handler: Handler): void {
+    this.handlers.set(name, handler);
+  }
+
+  async execute(
+    request: ExecutionRequest,
+    signal: AbortSignal,
+  ): Promise<ExecutionOutcome> {
+    const handler = this.handlers.get(request.function_name);
+    if (!handler) {
+      return errorOutcome(request, "handler_not_found", "Handler not found");
+    }
+
+    try {
+      const result = await handler(request, signal);
+      if (isExecutionOutcome(result)) {
+        return result;
+      }
+      return {
+        job_id: request.job_id,
+        request_id: request.request_id,
+        status: "success",
+        result,
+      };
+    } catch (error) {
+      if (isAbortError(error)) {
+        return errorOutcome(request, "cancelled", "Job cancelled");
+      }
+      return errorOutcome(request, undefined, asErrorMessage(error));
+    }
+  }
+}
+
+interface InFlightTask {
+  controller: AbortController;
+  respond: (outcome: ExecutionOutcome) => Promise<void>;
+  job_id: string;
+}
+
+export class ExecutorRuntime {
+  private registry: Registry;
+  private inFlight = new Map<string, InFlightTask>();
+  private jobIndex = new Map<string, string>();
+
+  constructor(registry: Registry) {
+    this.registry = registry;
+  }
+
+  async runFromEnv(): Promise<void> {
+    const socketPath = process.env[ENV_EXECUTOR_SOCKET];
+    const tcpSocket = process.env[ENV_EXECUTOR_TCP_SOCKET];
+    if (socketPath && tcpSocket) {
+      throw new Error("Provide only one of RRQ_EXECUTOR_SOCKET or RRQ_EXECUTOR_TCP_SOCKET");
+    }
+    if (tcpSocket) {
+      const address = parseTcpSocket(tcpSocket);
+      await this.runTcp(address.host, address.port);
+      return;
+    }
+    if (!socketPath) {
+      throw new Error(
+        `${ENV_EXECUTOR_SOCKET} or ${ENV_EXECUTOR_TCP_SOCKET} must be set`,
+      );
+    }
+    await this.runSocket(socketPath);
+  }
+
+  async runSocket(socketPath: string): Promise<void> {
+    await fs.promises.mkdir(path.dirname(socketPath), { recursive: true });
+    if (fs.existsSync(socketPath)) {
+      await fs.promises.unlink(socketPath);
+    }
+    await this.runServer({ path: socketPath });
+  }
+
+  async runTcp(host: string, port: number): Promise<void> {
+    await this.runServer({ host, port });
+  }
+
+  private async runServer(options: net.ListenOptions): Promise<void> {
+    const server = net.createServer((socket) => this.handleConnection(socket));
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(options, resolve);
+    });
+  }
+
+  private handleConnection(socket: net.Socket): void {
+    const parser = new FrameParser();
+    const activeRequests = new Set<string>();
+    let writeChain = Promise.resolve();
+
+    const enqueueWrite = (message: ExecutorMessage): Promise<void> => {
+      writeChain = writeChain.then(() => writeFrame(socket, message));
+      return writeChain;
+    };
+
+    const respond = async (outcome: ExecutionOutcome): Promise<void> => {
+      await enqueueWrite({ type: "response", payload: outcome });
+    };
+
+    const cleanupRequest = (requestId: string, jobId: string): void => {
+      this.inFlight.delete(requestId);
+      this.jobIndex.delete(jobId);
+      activeRequests.delete(requestId);
+    };
+
+    socket.on("data", (chunk) => {
+      const messages = parser.push(chunk);
+      for (const message of messages) {
+        if (message.type === "request") {
+          const request = message.payload;
+          if (request.protocol_version !== PROTOCOL_VERSION) {
+            void respond(
+              errorOutcome(
+                request,
+                "protocol",
+                "Unsupported protocol version",
+              ),
+            );
+            continue;
+          }
+
+          const controller = new AbortController();
+          const requestId = request.request_id;
+          const jobId = request.job_id;
+
+          this.inFlight.set(requestId, {
+            controller,
+            respond,
+            job_id: jobId,
+          });
+          this.jobIndex.set(jobId, requestId);
+          activeRequests.add(requestId);
+
+          void this.executeWithDeadline(request, controller.signal)
+            .then(async (outcome) => {
+              await respond(outcome);
+              cleanupRequest(requestId, jobId);
+            })
+            .catch(async (error) => {
+              await respond(errorOutcome(request, undefined, asErrorMessage(error)));
+              cleanupRequest(requestId, jobId);
+            });
+        } else if (message.type === "cancel") {
+          this.handleCancel(message.payload);
+        } else {
+          void respond({
+            job_id: "unknown",
+            request_id: null,
+            status: "error",
+            error: { message: "Unexpected response message" },
+          });
+        }
+      }
+    });
+
+    socket.on("close", () => {
+      for (const requestId of activeRequests) {
+        const task = this.inFlight.get(requestId);
+        if (task) {
+          task.controller.abort();
+          this.jobIndex.delete(task.job_id);
+          this.inFlight.delete(requestId);
+        }
+      }
+    });
+
+    socket.on("error", (error) => {
+      console.error("executor connection error:", error);
+      socket.destroy();
+    });
+  }
+
+  private async executeWithDeadline(
+    request: ExecutionRequest,
+    signal: AbortSignal,
+  ): Promise<ExecutionOutcome> {
+    const deadline = request.context.deadline;
+    if (!deadline) {
+      return this.registry.execute(request, signal);
+    }
+
+    const deadlineDate = new Date(deadline);
+    if (Number.isNaN(deadlineDate.getTime())) {
+      return errorOutcome(request, "deadline", "Invalid deadline timestamp");
+    }
+    const remainingMs = deadlineDate.getTime() - Date.now();
+    if (remainingMs <= 0) {
+      return timeoutOutcome(request, "Job deadline exceeded");
+    }
+
+    try {
+      return await withTimeout(
+        this.registry.execute(request, signal),
+        remainingMs,
+        signal,
+      );
+    } catch (error) {
+      if (isAbortError(error)) {
+        return errorOutcome(request, "cancelled", "Job cancelled");
+      }
+      if (error instanceof TimeoutError) {
+        return timeoutOutcome(request, "Job execution timed out");
+      }
+      return errorOutcome(request, undefined, asErrorMessage(error));
+    }
+  }
+
+  private handleCancel(payload: CancelRequest): void {
+    if (payload.protocol_version !== PROTOCOL_VERSION) {
+      return;
+    }
+    const requestId = payload.request_id ?? this.jobIndex.get(payload.job_id);
+    if (!requestId) {
+      return;
+    }
+    const task = this.inFlight.get(requestId);
+    if (!task) {
+      return;
+    }
+    task.controller.abort();
+    void task.respond({
+      job_id: payload.job_id,
+      request_id: requestId,
+      status: "error",
+      error: { message: "Job cancelled", type: "cancelled" },
+    });
+    this.inFlight.delete(requestId);
+    this.jobIndex.delete(task.job_id);
+  }
+}
+
+export function parseTcpSocket(value: string): { host: string; port: number } {
+  const raw = value.trim();
+  if (!raw) {
+    throw new Error("executor tcp_socket cannot be empty");
+  }
+
+  let host: string;
+  let portPart: string;
+  if (raw.startsWith("[")) {
+    const closing = raw.indexOf("]:");
+    if (closing === -1) {
+      throw new Error("executor tcp_socket must be in [host]:port format");
+    }
+    host = raw.slice(1, closing);
+    portPart = raw.slice(closing + 2);
+  } else {
+    const lastColon = raw.lastIndexOf(":");
+    if (lastColon === -1) {
+      throw new Error("executor tcp_socket must be in host:port format");
+    }
+    host = raw.slice(0, lastColon);
+    portPart = raw.slice(lastColon + 1);
+    if (!host) {
+      throw new Error("executor tcp_socket host cannot be empty");
+    }
+  }
+
+  const port = Number.parseInt(portPart, 10);
+  if (!Number.isFinite(port) || port <= 0 || port > 65535) {
+    throw new Error(`Invalid executor tcp_socket port: ${portPart}`);
+  }
+
+  if (host === "localhost") {
+    return { host: "127.0.0.1", port };
+  }
+  if (!net.isIP(host)) {
+    throw new Error(`Invalid executor tcp_socket host: ${host}`);
+  }
+  if (!isLoopback(host)) {
+    throw new Error("executor tcp_socket host must be localhost");
+  }
+  return { host, port };
+}
+
+class FrameParser {
+  private buffer = Buffer.alloc(0);
+
+  push(chunk: Buffer): ExecutorMessage[] {
+    this.buffer = Buffer.concat([this.buffer, chunk]);
+    const messages: ExecutorMessage[] = [];
+    while (this.buffer.length >= 4) {
+      const length = this.buffer.readUInt32BE(0);
+      if (length === 0) {
+        throw new Error("executor message payload cannot be empty");
+      }
+      if (length > MAX_FRAME_LEN) {
+        throw new Error("executor message payload too large");
+      }
+      if (this.buffer.length < 4 + length) {
+        break;
+      }
+      const payload = this.buffer.subarray(4, 4 + length);
+      this.buffer = this.buffer.subarray(4 + length);
+      const decoded = JSON.parse(payload.toString("utf-8")) as ExecutorMessage;
+      messages.push(decoded);
+    }
+    return messages;
+  }
+}
+
+async function writeFrame(
+  socket: net.Socket,
+  message: ExecutorMessage,
+): Promise<void> {
+  const payload = Buffer.from(JSON.stringify(message));
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(payload.length, 0);
+  await new Promise<void>((resolve, reject) => {
+    socket.write(Buffer.concat([header, payload]), (error) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+function errorOutcome(
+  request: ExecutionRequest,
+  type: string | undefined,
+  message: string,
+): ExecutionOutcome {
+  return {
+    job_id: request.job_id,
+    request_id: request.request_id,
+    status: "error",
+    error: {
+      message,
+      type: type ?? null,
+    },
+  };
+}
+
+function timeoutOutcome(request: ExecutionRequest, message: string): ExecutionOutcome {
+  return {
+    job_id: request.job_id,
+    request_id: request.request_id,
+    status: "timeout",
+    error: {
+      message,
+      type: "timeout",
+    },
+  };
+}
+
+function isExecutionOutcome(value: unknown): value is ExecutionOutcome {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as ExecutionOutcome;
+  return (
+    typeof candidate.status === "string" &&
+    typeof candidate.job_id === "string" &&
+    "request_id" in candidate
+  );
+}
+
+function asErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+function isAbortError(error: unknown): boolean {
+  if (!error) {
+    return false;
+  }
+  return (
+    error instanceof Error &&
+    (error.name === "AbortError" || error.message === "Job cancelled")
+  );
+}
+
+class TimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeoutError";
+  }
+}
+
+function createAbortError(): Error {
+  if (typeof globalThis.DOMException === "function") {
+    return new globalThis.DOMException("Job cancelled", "AbortError");
+  }
+  const fallback = new Error("Job cancelled");
+  fallback.name = "AbortError";
+  return fallback;
+}
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  signal: AbortSignal,
+): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  return new Promise<T>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(createAbortError());
+      return;
+    }
+
+    const onAbort = () => {
+      cleanup();
+      reject(createAbortError());
+    };
+
+    const cleanup = () => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      signal.removeEventListener("abort", onAbort);
+    };
+
+    signal.addEventListener("abort", onAbort);
+    timer = setTimeout(() => {
+      cleanup();
+      reject(new TimeoutError("Job execution timed out"));
+    }, timeoutMs);
+
+    promise
+      .then((value) => {
+        cleanup();
+        resolve(value);
+      })
+      .catch((error) => {
+        cleanup();
+        reject(error);
+      });
+  });
+}
+
+function isLoopback(host: string): boolean {
+  if (net.isIP(host) === 4) {
+    return host.startsWith("127.");
+  }
+  return host === "::1";
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const registry = new Registry();
+  registry.register("echo", (request) => ({
+    job_id: request.job_id,
+    request_id: request.request_id,
+    status: "success",
+    result: { job_id: request.job_id },
+  }));
+
+  const runtime = new ExecutorRuntime(registry);
+  runtime
+    .runFromEnv()
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    })
+    .finally(() => {
+      process.exitCode = process.exitCode ?? 0;
+    });
+}

--- a/rrq-ts/src/index.ts
+++ b/rrq-ts/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./producer.js";
+export * from "./executor_runtime.js";
+export * from "./settings.js";
+export * from "./constants.js";

--- a/rrq-ts/src/producer.ts
+++ b/rrq-ts/src/producer.ts
@@ -1,0 +1,198 @@
+import crypto from "node:crypto";
+import Redis from "ioredis";
+import {
+  JOB_KEY_PREFIX,
+  QUEUE_KEY_PREFIX,
+  UNIQUE_JOB_LOCK_PREFIX,
+} from "./constants.js";
+import { DEFAULT_SETTINGS, resolveSettings, RRQSettings } from "./settings.js";
+
+export interface EnqueueOptions {
+  args?: unknown[];
+  kwargs?: Record<string, unknown>;
+  queueName?: string;
+  jobId?: string;
+  uniqueKey?: string;
+  maxRetries?: number;
+  jobTimeoutSeconds?: number;
+  resultTtlSeconds?: number;
+  deferUntil?: Date;
+  deferBySeconds?: number;
+  traceContext?: Record<string, string> | null;
+}
+
+export interface JobRecord {
+  id: string;
+  function_name: string;
+  job_args: string;
+  job_kwargs: string;
+  enqueue_time: string;
+  status: "PENDING";
+  current_retries: string;
+  queue_name: string;
+  next_scheduled_run_time: string;
+  max_retries: string;
+  job_timeout_seconds: string;
+  result_ttl_seconds: string;
+  job_unique_key?: string;
+  result: string;
+  trace_context?: string;
+}
+
+export class RRQClient {
+  private settings: RRQSettings;
+  private redis: Redis;
+  private ownsRedis: boolean;
+
+  constructor(settings?: Partial<RRQSettings>, redis?: Redis) {
+    this.settings = resolveSettings(settings);
+    if (redis) {
+      this.redis = redis;
+      this.ownsRedis = false;
+    } else {
+      this.redis = new Redis(this.settings.redisDsn);
+      this.ownsRedis = true;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.ownsRedis) {
+      await this.redis.quit();
+    }
+  }
+
+  async enqueue(functionName: string, options: EnqueueOptions = {}): Promise<string> {
+    const args = options.args ?? [];
+    const kwargs = options.kwargs ?? {};
+    const queueName = options.queueName ?? this.settings.defaultQueueName;
+    const jobId = options.jobId ?? crypto.randomUUID();
+
+    const enqueueTime = new Date();
+    let desiredRunTime = enqueueTime;
+    let lockTtlSeconds = this.settings.defaultUniqueJobLockTtlSeconds;
+
+    if (options.deferUntil) {
+      const deferUntil = ensureUtcDate(options.deferUntil);
+      desiredRunTime = deferUntil;
+      const diffSeconds = Math.max(
+        0,
+        Math.ceil((deferUntil.getTime() - enqueueTime.getTime()) / 1000),
+      );
+      lockTtlSeconds = Math.max(lockTtlSeconds, diffSeconds + 1);
+    } else if (typeof options.deferBySeconds === "number") {
+      const deferSeconds = Math.max(0, Math.floor(options.deferBySeconds));
+      desiredRunTime = new Date(enqueueTime.getTime() + deferSeconds * 1000);
+      lockTtlSeconds = Math.max(lockTtlSeconds, deferSeconds + 1);
+    }
+
+    let uniqueAcquired = false;
+    if (options.uniqueKey) {
+      const remainingTtl = await this.getLockTtl(options.uniqueKey);
+      if (remainingTtl > 0) {
+        desiredRunTime = new Date(
+          Math.max(
+            desiredRunTime.getTime(),
+            enqueueTime.getTime() + remainingTtl * 1000,
+          ),
+        );
+      } else {
+        uniqueAcquired = await this.acquireUniqueJobLock(
+          options.uniqueKey,
+          jobId,
+          lockTtlSeconds,
+        );
+        if (!uniqueAcquired) {
+          const remaining = await this.getLockTtl(options.uniqueKey);
+          desiredRunTime = new Date(
+            Math.max(
+              desiredRunTime.getTime(),
+              enqueueTime.getTime() + remaining * 1000,
+            ),
+          );
+        }
+      }
+    }
+
+    const jobRecord: JobRecord = {
+      id: jobId,
+      function_name: functionName,
+      job_args: JSON.stringify(args),
+      job_kwargs: JSON.stringify(kwargs),
+      enqueue_time: enqueueTime.toISOString(),
+      status: "PENDING",
+      current_retries: "0",
+      queue_name: queueName,
+      next_scheduled_run_time: desiredRunTime.toISOString(),
+      max_retries: String(options.maxRetries ?? this.settings.defaultMaxRetries),
+      job_timeout_seconds: String(
+        options.jobTimeoutSeconds ?? this.settings.defaultJobTimeoutSeconds,
+      ),
+      result_ttl_seconds: String(
+        options.resultTtlSeconds ?? this.settings.defaultResultTtlSeconds,
+      ),
+      result: JSON.stringify(null),
+    };
+
+    if (options.uniqueKey) {
+      jobRecord.job_unique_key = options.uniqueKey;
+    }
+    if (options.traceContext) {
+      jobRecord.trace_context = JSON.stringify(options.traceContext);
+    }
+
+    const jobKey = `${JOB_KEY_PREFIX}${jobId}`;
+    const queueKey = formatQueueKey(queueName);
+    const score = desiredRunTime.getTime();
+
+    try {
+      const pipeline = this.redis.pipeline();
+      pipeline.hset(jobKey, jobRecord);
+      pipeline.zadd(queueKey, score, jobId);
+      await pipeline.exec();
+    } catch (error) {
+      if (uniqueAcquired && options.uniqueKey) {
+        await this.releaseUniqueJobLock(options.uniqueKey);
+      }
+      throw error;
+    }
+
+    return jobId;
+  }
+
+  private async acquireUniqueJobLock(
+    uniqueKey: string,
+    jobId: string,
+    ttlSeconds: number,
+  ): Promise<boolean> {
+    const lockKey = `${UNIQUE_JOB_LOCK_PREFIX}${uniqueKey}`;
+    const result = await this.redis.set(lockKey, jobId, "EX", ttlSeconds, "NX");
+    return result === "OK";
+  }
+
+  private async releaseUniqueJobLock(uniqueKey: string): Promise<void> {
+    const lockKey = `${UNIQUE_JOB_LOCK_PREFIX}${uniqueKey}`;
+    await this.redis.del(lockKey);
+  }
+
+  private async getLockTtl(uniqueKey: string): Promise<number> {
+    const lockKey = `${UNIQUE_JOB_LOCK_PREFIX}${uniqueKey}`;
+    const ttl = await this.redis.ttl(lockKey);
+    return typeof ttl === "number" && ttl > 0 ? ttl : 0;
+  }
+}
+
+export function formatQueueKey(queueName: string): string {
+  if (queueName.startsWith(QUEUE_KEY_PREFIX)) {
+    return queueName;
+  }
+  return `${QUEUE_KEY_PREFIX}${queueName}`;
+}
+
+function ensureUtcDate(value: Date): Date {
+  if (Number.isNaN(value.getTime())) {
+    throw new Error("Invalid deferUntil timestamp");
+  }
+  return value;
+}
+
+export { DEFAULT_SETTINGS };

--- a/rrq-ts/src/settings.ts
+++ b/rrq-ts/src/settings.ts
@@ -1,0 +1,35 @@
+import {
+  DEFAULT_DLQ_NAME,
+  DEFAULT_JOB_TIMEOUT_SECONDS,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_QUEUE_NAME,
+  DEFAULT_RESULT_TTL_SECONDS,
+  DEFAULT_UNIQUE_JOB_LOCK_TTL_SECONDS,
+} from "./constants.js";
+
+export interface RRQSettings {
+  redisDsn: string;
+  defaultQueueName: string;
+  defaultDlqName: string;
+  defaultMaxRetries: number;
+  defaultJobTimeoutSeconds: number;
+  defaultResultTtlSeconds: number;
+  defaultUniqueJobLockTtlSeconds: number;
+}
+
+export const DEFAULT_SETTINGS: RRQSettings = {
+  redisDsn: "redis://localhost:6379/0",
+  defaultQueueName: DEFAULT_QUEUE_NAME,
+  defaultDlqName: DEFAULT_DLQ_NAME,
+  defaultMaxRetries: DEFAULT_MAX_RETRIES,
+  defaultJobTimeoutSeconds: DEFAULT_JOB_TIMEOUT_SECONDS,
+  defaultResultTtlSeconds: DEFAULT_RESULT_TTL_SECONDS,
+  defaultUniqueJobLockTtlSeconds: DEFAULT_UNIQUE_JOB_LOCK_TTL_SECONDS,
+};
+
+export function resolveSettings(overrides?: Partial<RRQSettings>): RRQSettings {
+  return {
+    ...DEFAULT_SETTINGS,
+    ...overrides,
+  };
+}

--- a/rrq-ts/tsconfig.json
+++ b/rrq-ts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
### Motivation
- Provide a TypeScript/JavaScript implementation of RRQ producer and executor so Node/Bun environments can produce jobs and run executor handlers.
- Ship a publishable package scaffold with build config and documentation so the code can be built and distributed as `rrq-ts`.
- Ensure executor cancellation and deadline semantics behave consistently across runtimes by returning a reliable `AbortError` equivalent.

### Description
- Add a new `rrq-ts` package with `package.json`, `tsconfig.json`, `README.md`, and `LICENSE` to scaffold publishing and builds.
- Implement a TypeScript producer in `rrq-ts/src/producer.ts` that writes job hashes and queue entries compatible with the orchestrator and supports deferral and `uniqueKey` locking behavior.
- Implement a TypeScript executor runtime in `rrq-ts/src/executor_runtime.ts` (also added as `reference/typescript/executor_runtime.ts`) that implements the RRQ v1 socket protocol, frame parsing, `runSocket`/`runTcp`, deadline handling via `withTimeout`, and cancellation detection using `createAbortError()`.
- Add supporting modules: `rrq-ts/src/constants.ts`, `rrq-ts/src/settings.ts`, and `rrq-ts/src/index.ts`, and update `docs/EXECUTOR_PROTOCOL.md` to reference the TypeScript example.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697cab6e44b083309a74e58b2efed927)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Redis-writing producer logic and a network-facing executor runtime (socket/TCP parsing, cancellation, deadlines), which could impact job scheduling compatibility and runtime behavior despite being mostly additive.
> 
> **Overview**
> Adds a new publishable TypeScript package, `rrq-ts`, providing a Redis-backed producer (`RRQClient.enqueue`) that writes RRQ-compatible job hashes/queue entries with support for deferral, retries/timeouts metadata, trace context, and best-effort `uniqueKey` locking.
> 
> Introduces a Node/Bun executor runtime implementing the v1 length-delimited socket protocol (Unix socket or localhost-only TCP), including handler registry execution, deadline-based timeouts, and cancellation via `AbortController`/`AbortError` semantics. Documentation is updated to list the TypeScript runtime as a reference implementation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a7dc3e97597de5e3571b93337fa5f4f0957c1814. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->