### PR TITLE
Add comprehensive runner config validation and TCP socket parsing

### DIFF
--- a/rrq-rs/config/src/defaults.rs
+++ b/rrq-rs/config/src/defaults.rs
@@ -1,3 +1,4 @@
+pub const DEFAULT_REDIS_DSN: &str = "redis://localhost:6379/0";
 pub const DEFAULT_QUEUE_NAME: &str = "rrq:queue:default";
 pub const DEFAULT_DLQ_NAME: &str = "rrq:dlq:default";
 

--- a/rrq-rs/config/src/lib.rs
+++ b/rrq-rs/config/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cron;
 pub mod defaults;
 pub mod producer;
 pub mod settings;
+pub mod tcp_socket;
 
 pub use config::{
     DEFAULT_CONFIG_FILENAME, ENV_CONFIG_KEY, load_toml_settings, resolve_config_source,
@@ -11,3 +12,4 @@ pub use cron::CronJob;
 pub use defaults::*;
 pub use producer::{ProducerSettings, load_producer_settings};
 pub use settings::{RRQSettings, RunnerConfig, RunnerType, WatchSettings};
+pub use tcp_socket::{TcpSocketSpec, parse_tcp_socket};

--- a/rrq-rs/config/src/settings.rs
+++ b/rrq-rs/config/src/settings.rs
@@ -18,6 +18,7 @@ pub enum RunnerType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct RunnerConfig {
     #[serde(default = "default_runner_type", rename = "type")]
     pub runner_type: RunnerType,

--- a/rrq-rs/config/src/settings.rs
+++ b/rrq-rs/config/src/settings.rs
@@ -6,8 +6,8 @@ use crate::cron::CronJob;
 use crate::defaults::{
     DEFAULT_DLQ_NAME, DEFAULT_EXPECTED_JOB_TTL, DEFAULT_JOB_TIMEOUT_SECONDS,
     DEFAULT_LOCK_TIMEOUT_EXTENSION_SECONDS, DEFAULT_MAX_RETRIES, DEFAULT_POLL_DELAY_SECONDS,
-    DEFAULT_QUEUE_NAME, DEFAULT_RESULT_TTL_SECONDS, DEFAULT_RUNNER_CONNECT_TIMEOUT_MS,
-    DEFAULT_UNIQUE_JOB_LOCK_TTL_SECONDS,
+    DEFAULT_QUEUE_NAME, DEFAULT_REDIS_DSN, DEFAULT_RESULT_TTL_SECONDS,
+    DEFAULT_RUNNER_CONNECT_TIMEOUT_MS, DEFAULT_UNIQUE_JOB_LOCK_TTL_SECONDS,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -72,7 +72,7 @@ pub struct RRQSettings {
 impl Default for RRQSettings {
     fn default() -> Self {
         Self {
-            redis_dsn: "redis://localhost:6379/0".to_string(),
+            redis_dsn: DEFAULT_REDIS_DSN.to_string(),
             default_queue_name: DEFAULT_QUEUE_NAME.to_string(),
             default_dlq_name: DEFAULT_DLQ_NAME.to_string(),
             default_max_retries: DEFAULT_MAX_RETRIES,

--- a/rrq-rs/config/src/tcp_socket.rs
+++ b/rrq-rs/config/src/tcp_socket.rs
@@ -1,0 +1,126 @@
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use anyhow::{Context, Result};
+
+/// Parsed and validated TCP socket specification for a runner.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TcpSocketSpec {
+    pub host: IpAddr,
+    pub port: u16,
+}
+
+impl TcpSocketSpec {
+    /// Returns a socket address with the given port (used for pool port allocation).
+    pub fn addr(&self, port: u16) -> SocketAddr {
+        SocketAddr::new(self.host, port)
+    }
+}
+
+/// Parses and validates a tcp_socket string (e.g., "127.0.0.1:9000").
+///
+/// Validates:
+/// - Format is `host:port` or `[ipv6]:port`
+/// - Host is localhost/loopback only (127.0.0.1, ::1, localhost)
+/// - Port is > 0 and <= 65535
+pub fn parse_tcp_socket(raw: &str) -> Result<TcpSocketSpec> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(anyhow::anyhow!("tcp_socket cannot be empty"));
+    }
+
+    let (host, port_str) = if let Some(rest) = raw.strip_prefix('[') {
+        // IPv6 format: [::1]:port
+        let (host, port_str) = rest
+            .split_once("]:")
+            .ok_or_else(|| anyhow::anyhow!("tcp_socket must be in [host]:port format"))?;
+        (host, port_str)
+    } else {
+        // IPv4 or hostname format: host:port
+        let (host, port_str) = raw
+            .rsplit_once(':')
+            .ok_or_else(|| anyhow::anyhow!("tcp_socket must be in host:port format"))?;
+        if host.is_empty() {
+            return Err(anyhow::anyhow!("tcp_socket host cannot be empty"));
+        }
+        (host, port_str)
+    };
+
+    let port: u16 = port_str
+        .parse()
+        .with_context(|| format!("invalid tcp_socket port '{port_str}' - must be 1-65535"))?;
+    if port == 0 {
+        return Err(anyhow::anyhow!("tcp_socket port must be > 0"));
+    }
+
+    let ip = if host == "localhost" {
+        IpAddr::V4(Ipv4Addr::LOCALHOST)
+    } else {
+        let parsed: IpAddr = host
+            .parse()
+            .with_context(|| format!("invalid tcp_socket host '{host}'"))?;
+        if !parsed.is_loopback() {
+            return Err(anyhow::anyhow!(
+                "tcp_socket host must be loopback (127.0.0.1, ::1, or localhost) for security - got '{host}'"
+            ));
+        }
+        parsed
+    };
+
+    Ok(TcpSocketSpec { host: ip, port })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_tcp_socket_ipv4_localhost() {
+        let spec = parse_tcp_socket("127.0.0.1:9000").unwrap();
+        assert_eq!(spec.host, IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
+        assert_eq!(spec.port, 9000);
+    }
+
+    #[test]
+    fn parse_tcp_socket_localhost_hostname() {
+        let spec = parse_tcp_socket("localhost:1234").unwrap();
+        assert_eq!(spec.host, IpAddr::V4(Ipv4Addr::LOCALHOST));
+        assert_eq!(spec.port, 1234);
+    }
+
+    #[test]
+    fn parse_tcp_socket_ipv6_loopback() {
+        let spec = parse_tcp_socket("[::1]:8080").unwrap();
+        assert!(spec.host.is_loopback());
+        assert_eq!(spec.port, 8080);
+    }
+
+    #[test]
+    fn parse_tcp_socket_rejects_non_loopback() {
+        let err = parse_tcp_socket("10.0.0.1:1234").unwrap_err();
+        assert!(err.to_string().contains("loopback"));
+    }
+
+    #[test]
+    fn parse_tcp_socket_rejects_zero_port() {
+        let err = parse_tcp_socket("127.0.0.1:0").unwrap_err();
+        assert!(err.to_string().contains("port must be > 0"));
+    }
+
+    #[test]
+    fn parse_tcp_socket_rejects_empty() {
+        let err = parse_tcp_socket("").unwrap_err();
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn parse_tcp_socket_rejects_missing_port() {
+        let err = parse_tcp_socket("127.0.0.1").unwrap_err();
+        assert!(err.to_string().contains("host:port"));
+    }
+
+    #[test]
+    fn parse_tcp_socket_rejects_invalid_port() {
+        let err = parse_tcp_socket("127.0.0.1:abc").unwrap_err();
+        assert!(err.to_string().contains("port"));
+    }
+}

--- a/rrq-rs/producer/src/ffi.rs
+++ b/rrq-rs/producer/src/ffi.rs
@@ -243,8 +243,8 @@ pub extern "C" fn rrq_producer_new(
 ) -> *mut ProducerHandle {
     with_unwind(error_out, || {
         let payload = take_cstr(config_json)?;
-        let config_payload: ProducerConfigPayload =
-            serde_json::from_str(&payload).map_err(|err| err.to_string())?;
+        let config_payload: ProducerConfigPayload = serde_json::from_str(&payload)
+            .map_err(|err| format!("invalid producer config: {err}"))?;
 
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
@@ -387,8 +387,8 @@ pub extern "C" fn rrq_producer_enqueue(
         }
 
         let payload = take_cstr(request_json)?;
-        let request: EnqueueRequestPayload =
-            serde_json::from_str(&payload).map_err(|err| err.to_string())?;
+        let request: EnqueueRequestPayload = serde_json::from_str(&payload)
+            .map_err(|err| format!("invalid enqueue request: {err}"))?;
 
         let args = request.args.unwrap_or_default();
         let kwargs = request.kwargs.unwrap_or_default();
@@ -566,8 +566,8 @@ pub extern "C" fn rrq_producer_get_job_status(
         }
 
         let payload = take_cstr(request_json)?;
-        let request: JobStatusRequestPayload =
-            serde_json::from_str(&payload).map_err(|err| err.to_string())?;
+        let request: JobStatusRequestPayload = serde_json::from_str(&payload)
+            .map_err(|err| format!("invalid job status request: {err}"))?;
 
         let producer_handle = unsafe { &*handle };
         let producer = producer_handle.producer.clone();


### PR DESCRIPTION
## Summary
This PR adds robust validation for runner configurations at load time and extracts TCP socket parsing into a reusable module. Configuration errors now provide helpful diagnostic hints, and invalid runner setups are caught early rather than at worker startup.

## Key Changes

- **New `tcp_socket` module**: Extracted TCP socket parsing logic from `orchestrator/runner.rs` into a dedicated `rrq_config::tcp_socket` module for reusability and testability
  - Validates socket format (`host:port` or `[ipv6]:port`)
  - Enforces loopback-only addresses (127.0.0.1, ::1, localhost) for security
  - Validates port range (1-65535)
  - Includes comprehensive unit tests

- **Enhanced config validation**: Added `validate_runner_configs()` function that validates:
  - Required fields: `cmd` and `tcp_socket` must be present
  - Field types and values: `pool_size` and `max_in_flight` must be positive integers
  - TCP socket format and loopback requirement
  - Port range doesn't overflow with `pool_size` (e.g., port 65535 + pool_size 2 would exceed u16::MAX)
  - `default_runner_name` references an actual configured runner

- **Improved error diagnostics**: Added `diagnose_config_error()` function that provides helpful hints for common configuration mistakes:
  - Unknown field names in runner configs (suggests valid fields)
  - Type errors (e.g., pool_size as string instead of integer)
  - Includes field suggestions in error messages

- **Config struct improvements**:
  - Added `#[serde(deny_unknown_fields)]` to `RunnerConfig` to catch typos early
  - Added `DEFAULT_REDIS_DSN` constant to `defaults.rs`

- **Removed duplicate code**: Removed `parse_tcp_socket()` and `TcpSocketSpec` from `orchestrator/runner.rs` and now imports from config crate

- **Test coverage**: Added 8 new integration tests covering valid configs and various validation failure scenarios

- **Minor improvements**: Improved error messages in FFI layer for producer config parsing

## Implementation Details

The validation happens in `load_toml_settings()` after deserialization, allowing serde to catch structural issues first, then applying semantic validation. This two-stage approach provides better error messages and clearer separation of concerns.

TCP socket validation is strict about loopback addresses to prevent accidental exposure of runner sockets to the network.

https://claude.ai/code/session_01CSZgwk1EcG5xP6LgpqRmYS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Stricter validation and `deny_unknown_fields` can cause previously accepted configs (typos, missing fields, non-loopback sockets) to fail fast, potentially impacting deployments; changes are localized to config parsing and runner setup.
> 
> **Overview**
> **Adds early, user-friendly runner config validation at config load time.** `load_toml_settings` now augments serde errors with targeted hints (unknown runner fields, common type mismatches) and runs semantic checks that `cmd`/`tcp_socket` are present, values are positive, `default_runner_name` exists, and `tcp_socket` has enough port range for `pool_size`.
> 
> **Extracts and hardens TCP socket parsing into `rrq_config`.** Introduces `tcp_socket.rs` (loopback-only host enforcement, IPv4/IPv6 parsing, port validation) and updates the orchestrator to consume `rrq_config::{TcpSocketSpec, parse_tcp_socket}` instead of its local copy; adds `DEFAULT_REDIS_DSN` and tightens `RunnerConfig` with `#[serde(deny_unknown_fields)]`. Producer FFI JSON parsing errors are also prefixed with clearer context strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1444f89bbcff36010f2ee9a64a213a557f01238e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->