### PR TITLE
Feat: Version 0.9.10

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,35 @@ uv run ty check                   # Type check (must pass before commits)
 uv add <package>                  # Add dependency
 ```
 
+## Repo-Wide Testing
+```bash
+# Rust
+cd rrq-rs
+cargo fmt && cargo clippy
+cargo test
+
+# TypeScript (requires Bun)
+sh scripts/with-producer-lib.sh -- sh -c "cd rrq-ts && bun test"
+cd rrq-ts && bun run lint
+
+# Python (unit tests + warnings as errors)
+cd rrq-py
+uv run pytest
+uv run pytest -W error
+
+# Integration scenario runner (requires Redis + cargo + bun)
+sh scripts/with-producer-lib.sh -- uv run --project rrq-py python examples/integration_test.py
+# Smaller/isolated run (recommended if other RRQ processes are active)
+sh scripts/with-producer-lib.sh -- uv run --project rrq-py python examples/integration_test.py --count 100 --redis-dsn redis://localhost:6379/15
+```
+
+Notes:
+- `examples/integration_test.py` expects Redis running and an RRQ CLI binary
+  available (PATH or `rrq-py/rrq/bin/rrq`).
+- Use a dedicated Redis DB (`--redis-dsn redis://localhost:6379/15`) if any
+  other RRQ workers/executors are running to avoid protocol/version conflicts.
+- The `with-producer-lib.sh` wrapper builds and exports the producer FFI lib.
+
 ## Code Style
 - Python 3.11+, double quotes, 88 char lines
 - Type hints on all functions, Pydantic V2 for validation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,35 @@ uv run ty check                   # Type check (must pass before commits)
 uv add <package>                  # Add dependency
 ```
 
+## Repo-Wide Testing
+```bash
+# Rust
+cd rrq-rs
+cargo fmt && cargo clippy
+cargo test
+
+# TypeScript (requires Bun)
+sh scripts/with-producer-lib.sh -- sh -c "cd rrq-ts && bun test"
+cd rrq-ts && bun run lint
+
+# Python (unit tests + warnings as errors)
+cd rrq-py
+uv run pytest
+uv run pytest -W error
+
+# Integration scenario runner (requires Redis + cargo + bun)
+sh scripts/with-producer-lib.sh -- uv run --project rrq-py python examples/integration_test.py
+# Smaller/isolated run (recommended if other RRQ processes are active)
+sh scripts/with-producer-lib.sh -- uv run --project rrq-py python examples/integration_test.py --count 100 --redis-dsn redis://localhost:6379/15
+```
+
+Notes:
+- `examples/integration_test.py` expects Redis running and an RRQ CLI binary
+  available (PATH or `rrq-py/rrq/bin/rrq`).
+- Use a dedicated Redis DB (`--redis-dsn redis://localhost:6379/15`) if any
+  other RRQ workers/executors are running to avoid protocol/version conflicts.
+- The `with-producer-lib.sh` wrapper builds and exports the producer FFI lib.
+
 ## Code Style
 - Python 3.11+, double quotes, 88 char lines
 - Type hints on all functions, Pydantic V2 for validation

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Most job queues make you choose: either fight with complex distributed systems c
 │     Your Application         │
 │  (Python, TypeScript, Rust)  │
 │                              │
-│   client.enqueue("job", {})  │
+│ client.enqueue("job", {...}) │
 └───────────────┬──────────────┘
                 │ enqueue jobs
                 ▼
@@ -118,7 +118,7 @@ rrq worker run --config rrq.toml
 from rrq.client import RRQClient
 
 client = RRQClient(config_path="rrq.toml")
-job_id = await client.enqueue("send_email", {"email": "user@example.com"})
+job_id = await client.enqueue("send_email", {"params": {"email": "user@example.com"}})
 ```
 
 ## Quick Start (TypeScript)

--- a/README.md
+++ b/README.md
@@ -1,286 +1,182 @@
 # RRQ: Reliable Redis Queue
 
-RRQ is a Redis-backed job queue **system** with a Rust orchestrator and a
-language-agnostic runner protocol. Producers can enqueue jobs from Python,
-Rust, or any language that can write the job schema to Redis. Runners can be
-written in any language that can speak the socket protocol. The orchestrator is
-implemented in Rust, with runners available in multiple languages.
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
-## At a Glance
+**A distributed job queue that actually works.** RRQ combines a battle-tested Rust orchestrator with language-flexible workers, giving you the reliability of proven infrastructure with the flexibility of writing job handlers in Python, TypeScript, or Rust.
 
-- **Rust orchestrator**: schedules, retries, timeouts, DLQ, cron.
-- **TCP runners**: Python, TypeScript, Rust, or any other runtime.
-- **Python + TypeScript SDKs**: enqueue jobs and run runner runtimes.
+## Why RRQ?
 
-## Repo Layout
+Most job queues make you choose: either fight with complex distributed systems concepts, or accept unreliable "good enough" solutions. RRQ takes a different approach:
 
-- `.github/` CI workflows
-- `docs/` design docs, protocols, references
-- `examples/` Python + Rust usage samples
-- `rrq-py/` Python package (`rrq`), tests, and build tooling
-- `rrq-rs/` Rust workspace (orchestrator, producer, runner, protocol)
-- `rrq-ts/` TypeScript package (producer + runner runtime)
+- **Rust orchestrator, any-language workers** - The hard parts (scheduling, retries, locking, timeouts) are handled by a single-binary Rust orchestrator. Your job handlers are just normal async functions in your preferred language.
+
+- **Redis as the source of truth** - No separate databases to manage. Jobs, queues, locks, and results all live in Redis with atomic operations and predictable semantics.
+
+- **Production-grade features built in** - Retry policies, dead letter queues, job timeouts, cron scheduling, distributed tracing, and health checks work out of the box.
+
+- **Fast and lightweight** - The Rust orchestrator handles thousands of jobs per second with minimal memory. Workers are isolated processes that can be scaled independently.
 
 ## Architecture
 
 ```
 ┌──────────────────────────────┐
-│        Producers SDKs        │
-│ (Python, TypeScript, Rust,   │
-│        other langs)          │
+│     Your Application         │
+│  (Python, TypeScript, Rust)  │
+│                              │
+│   client.enqueue("job", {})  │
 └───────────────┬──────────────┘
                 │ enqueue jobs
                 ▼
       ┌───────────────────────┐
       │         Redis         │
-      │  - queues (ZSETs)     │
-      │  - job hashes         │
-      │  - locks              │
-      │  - DLQ lists          │
+      │  queues, jobs, locks  │
       └──────────┬────────────┘
-                 │ poll/lock
+                 │ poll/dispatch
                  ▼
       ┌──────────────────────────────┐
-      │   Rust RRQ Orchestrator      │
-      │     (rrq worker run)         │
-      │ - scheduling + retries       │
-      │ - timeouts + DLQ             │
-      │ - queue routing              │
-      │ - cron jobs                  │
+      │     RRQ Orchestrator         │
+      │   (single Rust binary)       │
+      │ • scheduling & retries       │
+      │ • timeouts & deadlines       │
+      │ • dead letter queue          │
+      │ • cron jobs                  │
       └──────────┬───────────────────┘
-                 │ TCP socket protocol
-                 │ (request <-> outcome)
+                 │ socket protocol
                  ▼
-   ┌─────────────────────┬─────────────────────┐
-   │ Python/TS Runner   │ Rust/Other Runner │
-   │ (rrq-runner)       │ (rrq-runner)      │
-   └───────────────────────────────────────────┘
+   ┌─────────────────────────────────────────┐
+   │              Job Runners                 │
+   │  ┌─────────────┐    ┌─────────────┐     │
+   │  │   Python    │    │ TypeScript  │     │
+   │  │   Worker    │    │   Worker    │     │
+   │  └─────────────┘    └─────────────┘     │
+   └─────────────────────────────────────────┘
 ```
 
-Runners return outcomes to the orchestrator; the orchestrator persists job
-state/results back to Redis.
+## Packages
 
-## Requirements
+| Package | Language | Purpose | Install |
+|---------|----------|---------|---------|
+| [rrq](https://pypi.org/project/rrq/) | Python | Producer + runner | `pip install rrq` |
+| [rrq-ts](https://www.npmjs.com/package/rrq-ts) | TypeScript | Producer + runner | `npm install rrq-ts` |
+| [rrq](https://crates.io/crates/rrq) | Rust | Orchestrator CLI | `cargo install rrq` |
+| [rrq-producer](https://crates.io/crates/rrq-producer) | Rust | Native producer | `rrq-producer = "0.9"` |
+| [rrq-runner](https://crates.io/crates/rrq-runner) | Rust | Native runner | `rrq-runner = "0.9"` |
 
-- Python 3.11+ (producer + Python runner runtime)
-- Node.js 20+ or Bun (TypeScript producer + runner runtime)
-- Rust `rrq` binary (bundled in wheels or provided separately)
-- Redis 5.0+
+## Quick Start (Python)
 
-If you ship the Rust binary separately, set `RRQ_RUST_BIN` to its path.
+### 1. Install
 
-## Quickstart
-
-### 1) Install
-
-```
-uv pip install rrq
+```bash
+pip install rrq
 ```
 
-### 2) Create `rrq.toml`
+### 2. Create configuration (`rrq.toml`)
 
 ```toml
 [rrq]
-redis_dsn = "redis://localhost:6379/1"
+redis_dsn = "redis://localhost:6379/0"
 default_runner_name = "python"
 
 [rrq.runners.python]
 type = "socket"
-cmd = ["rrq-runner", "--settings", "myapp.runner_config.python_runner_settings"]
-# Required: localhost TCP socket (host:port). For pool_size > 1, ports increment.
+cmd = ["rrq-runner", "--settings", "myapp.runner:settings"]
 tcp_socket = "127.0.0.1:9000"
 ```
 
-### 3) Register Python handlers
+### 3. Write a handler
 
 ```python
-# runner_config.py
-from rrq.runner_settings import PythonRunnerSettings
-from rrq.registry import Registry
+# myapp/handlers.py
+async def send_email(request):
+    email = request.params.get("email")
+    await do_send_email(email)
+    return {"sent": True}
+```
 
-from . import handlers
+### 4. Register and configure
+
+```python
+# myapp/runner.py
+from rrq.registry import Registry
+from rrq.runner_settings import PythonRunnerSettings
+from myapp import handlers
 
 registry = Registry()
-registry.register("process_message", handlers.process_message)
-
-python_runner_settings = PythonRunnerSettings(
-    registry=registry,
-)
+registry.register("send_email", handlers.send_email)
+settings = PythonRunnerSettings(registry=registry)
 ```
 
-### 4) Run the Python runner
+### 5. Run
 
-```
-rrq-runner --settings myapp.runner_config.python_runner_settings
-```
-
-### 5) Run the Rust orchestrator
-
-```
+```bash
 rrq worker run --config rrq.toml
 ```
 
-### 6) Enqueue jobs (Python)
+### 6. Enqueue jobs
 
 ```python
-import asyncio
 from rrq.client import RRQClient
 
-async def main():
-    client = RRQClient(config_path="rrq.toml")
-    await client.enqueue("process_message", {"args": ["hello"]})
-    await client.close()
-
-asyncio.run(main())
+client = RRQClient(config_path="rrq.toml")
+job_id = await client.enqueue("send_email", {"email": "user@example.com"})
 ```
 
-## TypeScript (Producer + Runner)
+## Quick Start (TypeScript)
 
-### Install
+```typescript
+import { RRQClient, RunnerRuntime, Registry } from "rrq-ts";
 
-```
-npm install rrq-ts
-```
+// Enqueue jobs
+const client = new RRQClient({ config: { redisDsn: "redis://localhost:6379/0" } });
+await client.enqueue("send_email", { params: { email: "user@example.com" } });
 
-### Enqueue jobs (TypeScript)
-
-```ts
-import { RRQClient } from "rrq-ts";
-
-const client = new RRQClient({
-  config: { redisDsn: "redis://localhost:6379/1" },
-});
-await client.enqueue("process_message", { args: ["hello"] });
-await client.close();
-```
-
-### Run a TypeScript runner
-
-```ts
-import { RunnerRuntime, Registry } from "rrq-ts";
-
+// Run handlers
 const registry = new Registry();
-registry.register("process_message", async (request) => ({
+registry.register("send_email", async (request) => ({
   job_id: request.job_id,
   request_id: request.request_id,
   status: "success",
-  result: { ok: true },
+  result: { sent: true }
 }));
-
 const runtime = new RunnerRuntime(registry);
 await runtime.runFromEnv();
 ```
 
-The TypeScript producer uses the Rust `rrq_producer` shared library via FFI.
-See `rrq-ts/README.md` for how to provide the shared library in local dev or
-published packages.
+## Features
 
-For packaging details (wheels + npm), see `docs/FFI_PACKAGING.md`.
+- **Scheduled jobs** - Defer execution by seconds or until a specific time
+- **Unique jobs** - Idempotency with unique keys
+- **Rate limiting** - Throttle job execution per key
+- **Debouncing** - Deduplicate rapid submissions
+- **Cron scheduling** - Recurring jobs with cron syntax
+- **Dead letter queue** - Failed jobs are preserved for debugging
+- **Distributed tracing** - OpenTelemetry context propagation
+- **Watch mode** - Auto-restart runners on code changes
 
-## Telemetry
-
-RRQ runners can emit OpenTelemetry spans (`rrq.runner`). Producers can attach
-`trace_context` on enqueue to link traces from producer → runner. See
-`docs/TELEMETRY.md` for end-to-end examples with Python/TypeScript/Rust.
-
-## Configuration
-
-`rrq.toml` is the source of truth for the orchestrator and runners. Key areas:
-
-- `[rrq]` basic settings (Redis, retries, timeouts, poll delay)
-- `[rrq.runners.<name>]` runner commands, pool sizes, and
-  `max_in_flight`
-- `[rrq.runner_routes]` queue → runner mapping (legacy `[rrq.routing]` still
-  accepted)
-- `[[rrq.cron_jobs]]` periodic scheduling
-- `[rrq.watch]` watch mode defaults (path/patterns)
-
-See `docs/CONFIG_REFERENCE.md` for the full TOML schema,
-`docs/CLI_REFERENCE.md` for CLI details, and `docs/RUNNER_PROTOCOL.md` for
-wire format.
-
-## Cron Jobs (rrq.toml)
-
-Use `[[rrq.cron_jobs]]` entries to enqueue periodic jobs while a worker is
-running. Schedules are evaluated in UTC.
-
-```toml
-[[rrq.cron_jobs]]
-function_name = "process_message"
-schedule = "0 * * * * *"
-args = ["cron payload"]
-kwargs = { source = "cron" }
-queue_name = "default"
-unique = true
-```
-
-Fields:
-- `function_name` (required): Handler name to enqueue.
-- `schedule` (required): Cron expression with seconds (6-field format).
-- `args` / `kwargs`: Optional arguments passed to the handler.
-- `queue_name`: Optional override for the target queue.
-- `unique`: Optional; uses a per-function unique lock to prevent duplicates.
-
-## CLI Overview (Rust `rrq`)
-
-- `rrq worker run`, `rrq worker watch`
-- `rrq check`
-- `rrq queue list|stats|inspect`
-- `rrq job show|list|trace|replay|cancel`
-- `rrq dlq list|stats|inspect|requeue`
-- `rrq debug generate-jobs|generate-workers|submit|clear|stress-test`
-
-## Worker Watch Mode
-
-`rrq worker watch` runs a normal worker loop plus a filesystem watcher. It
-watches a path recursively and normalizes change paths before matching include
-globs (default `*.py`, `*.toml`) and ignore globs. A matching change triggers a
-graceful worker shutdown, closes runners, and starts a fresh worker. Watch
-mode is intended for local development; runner pool sizes and
-`max_in_flight` are forced to 1 to keep restarts lightweight. It also respects
-`.gitignore` and `.git/info/exclude` by default; disable with `--no-gitignore`.
-
-You can also configure watch defaults in `rrq.toml`:
-
-```toml
-[rrq.watch]
-path = "."
-include_patterns = ["*.py", "*.toml"]
-ignore_patterns = [".venv/**", "dist/**"]
-no_gitignore = false
-```
-
-## Runner Logs
-
-Runners can emit logs to stdout/stderr. The orchestrator captures these lines
-and emits them with runner prefixes. Structured logging is not part of the
-wire protocol.
-
-## Testing
-
-Runtime-only Python tests (producer + runner + store):
+## Repository Structure
 
 ```
-cd rrq-py
-uv run pytest
+rrq/
+├── docs/           # Documentation
+├── examples/       # Usage examples
+├── rrq-py/         # Python package
+├── rrq-rs/         # Rust workspace (orchestrator, producer, runner, protocol)
+└── rrq-ts/         # TypeScript package
 ```
 
-End-to-end integration (Python-only, Rust-only, mixed):
+## Requirements
 
-```
-cd rrq-py
-uv run python ../examples/integration_test.py
-```
+- Redis 5.0+
+- Python 3.11+ (for Python SDK)
+- Node.js 20+ or Bun (for TypeScript SDK)
 
-## Reference Implementations
+## Documentation
 
-- Rust orchestrator (crate `rrq`): `rrq-rs/orchestrator`
-- Rust producer: `rrq-rs/producer`
-- Rust runner: `rrq-rs/runner`
-- Protocol types: `rrq-rs/protocol`
-- Python runner examples: `examples/python/`
+- [Configuration Reference](docs/CONFIG_REFERENCE.md)
+- [CLI Reference](docs/CLI_REFERENCE.md)
+- [Runner Protocol](docs/RUNNER_PROTOCOL.md)
+- [Telemetry](docs/TELEMETRY.md)
 
-## Telemetry
+## License
 
-Optional tracing integrations are available for Python producers and the Python
-runner runtime. See `rrq-py/rrq/integrations/`.
+Apache-2.0

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -103,7 +103,7 @@ Options:
 - `--limit` Max rows (default: 20)
 
 ### `rrq job replay <job_id>`
-Re-enqueue with original args/kwargs.
+Re-enqueue with original params.
 
 Options:
 - `--config` Path to `rrq.toml` (optional)
@@ -190,8 +190,8 @@ Submit a one-off job.
 
 Options:
 - `--config` Path to `rrq.toml` (optional)
-- `--args` JSON args array
-- `--kwargs` JSON kwargs object
+- `--args` JSON args array (deprecated; stored under `params.args`)
+- `--kwargs` JSON params object
 - `--queue` Queue name
 - `--delay` Delay in seconds
 

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -105,8 +105,7 @@ Schedule periodic jobs while a worker is running.
 [[rrq.cron_jobs]]
 function_name = "process_message"
 schedule = "0 * * * * *"
-args = ["cron payload"]
-kwargs = { source = "cron" }
+params = { payload = "cron payload", source = "cron" }
 queue_name = "default"
 unique = true
 ```
@@ -115,8 +114,7 @@ unique = true
 | --- | --- | --- | --- |
 | `function_name` | string | required | Handler name to enqueue. |
 | `schedule` | string | required | Cron expression with seconds (6 fields, UTC). |
-| `args` | array | `[]` | Positional args. |
-| `kwargs` | table | `{}` | Keyword args. |
+| `params` | table | `{}` | Job parameters. |
 | `queue_name` | string | — | Override target queue. |
 | `unique` | bool | `false` | Prevent duplicates with a per-function lock. |
 

--- a/docs/PARITY_SPEC.md
+++ b/docs/PARITY_SPEC.md
@@ -6,10 +6,14 @@ All language bindings must follow this spec to maintain parity.
 ## Producer API
 
 ### Required operations
-- `enqueue(function_name, args, kwargs, options) -> job_id`
+- `enqueue(function_name, params, options) -> job_id`
 - `enqueue_with_rate_limit(function_name, options) -> job_id | null`
 - `enqueue_with_debounce(function_name, options) -> job_id`
 - `get_job_status(job_id) -> JobResult | null`
+
+`params` is the job payload object. Language bindings may accept it as a
+separate argument (Rust) or as `options.params` (Python/TypeScript), but it
+must serialize to the same `job_params` payload in Redis.
 
 ### Producer config
 All bindings must accept the same producer configuration values:

--- a/docs/RUNNER_PROTOCOL.md
+++ b/docs/RUNNER_PROTOCOL.md
@@ -1,8 +1,11 @@
-# RRQ Runner Protocol (v1)
+# RRQ Runner Protocol (v2)
 
 This protocol defines the contract between the RRQ orchestrator (Rust `rrq`
-worker) and runner runtimes (Python, Rust, or any other language). The v1
+worker) and runner runtimes (Python, Rust, or any other language). The v2
 transport is a localhost TCP socket with length-delimited JSON frames.
+
+> **Note**: Protocol v2 replaced `args`/`kwargs` with a single `params` object.
+> The orchestrator and runners must use the same protocol version.
 
 ## Design Goals
 - **Centralized scheduling** in the Rust orchestrator (timeouts, retries, DLQ).
@@ -48,12 +51,11 @@ as needed.
 ## ExecutionRequest (payload)
 ```json
 {
-  "protocol_version": "1",
+  "protocol_version": "2",
   "request_id": "uuid",
   "job_id": "uuid",
   "function_name": "my_handler",
-  "args": [1, "two"],
-  "kwargs": {"flag": true},
+  "params": {"key": "value", "count": 42},
   "context": {
     "job_id": "uuid",
     "attempt": 1,
@@ -67,12 +69,11 @@ as needed.
 ```
 
 ### Fields
-- `protocol_version` (string): Always `"1"` for v1.
+- `protocol_version` (string): Always `"2"` for v2.
 - `request_id` (string): Unique ID for this request/response pair.
 - `job_id` (string): Unique job ID.
 - `function_name` (string): Handler name to execute.
-- `args` (array): Positional arguments.
-- `kwargs` (object): Keyword arguments.
+- `params` (object): Job parameters as key-value pairs.
 - `context` (object):
   - `job_id` (string)
   - `attempt` (int): 1-based attempt number.
@@ -146,7 +147,7 @@ override per policy.
 ## CancelRequest (payload)
 ```json
 {
-  "protocol_version": "1",
+  "protocol_version": "2",
   "job_id": "uuid",
   "request_id": "uuid (optional)",
   "hard_kill": false
@@ -154,7 +155,7 @@ override per policy.
 ```
 
 ### Fields
-- `protocol_version` (string): Always `"1"` for v1.
+- `protocol_version` (string): Always `"2"` for v2.
 - `job_id` (string): Job ID to cancel.
 - `request_id` (string, optional): If present, cancel only the matching
   in-flight request.

--- a/docs/RUNNER_PROTOCOL.md
+++ b/docs/RUNNER_PROTOCOL.md
@@ -17,7 +17,7 @@ transport is a localhost TCP socket with length-delimited JSON frames.
 - Timestamps are **RFC 3339** (UTC).
 - Field names are **snake_case**.
 
-## Transport (v1)
+## Transport (v2)
 - The orchestrator sets `RRQ_RUNNER_TCP_SOCKET` to a `host:port` value.
 - The runner **binds** a TCP socket on the provided **localhost-only**
   address and accepts connections.

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -25,10 +25,11 @@ carrier: dict[str, str] = {}
 propagate.inject(carrier)
 
 client = RRQClient(config_path="rrq.toml")
-await client.enqueue("process_message", {
-    "args": ["hello"],
-    "trace_context": carrier,
-})
+await client.enqueue(
+    "process_message",
+    {"message": "hello"},
+    trace_context=carrier,
+)
 ```
 
 ### TypeScript
@@ -42,7 +43,7 @@ propagation.inject(context.active(), carrier);
 
 const client = new RRQClient({ configPath: "rrq.toml" });
 await client.enqueue("process_message", {
-  args: ["hello"],
+  params: { message: "hello" },
   traceContext: carrier,
 });
 ```

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -27,8 +27,7 @@ propagate.inject(carrier)
 client = RRQClient(config_path="rrq.toml")
 await client.enqueue(
     "process_message",
-    {"message": "hello"},
-    trace_context=carrier,
+    {"params": {"message": "hello"}, "trace_context": carrier},
 )
 ```
 
@@ -54,13 +53,16 @@ await client.enqueue("process_message", {
 use std::collections::HashMap;
 use opentelemetry::global;
 use rrq_producer::{Producer, EnqueueOptions};
+use serde_json::{json, Map, Value};
 
 let mut carrier = HashMap::new();
 global::get_text_map_propagator(|prop| prop.inject(&mut carrier));
 
 let mut options = EnqueueOptions::default();
 options.trace_context = Some(carrier);
-producer.enqueue("process_message", vec![], Default::default(), options).await?;
+let mut params: Map<String, Value> = Map::new();
+params.insert("message".to_string(), json!("hello"));
+producer.enqueue("process_message", params, options).await?;
 ```
 
 ## Runner: enable OpenTelemetry spans

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -126,19 +126,19 @@ def _run(
 
 
 def _resolve_rrq_cmd() -> list[str]:
-    rrq_path = shutil.which("rrq")
-    if rrq_path:
-        return [rrq_path]
-
     repo_root = Path(__file__).resolve().parents[1]
     repo_candidates = [
-        repo_root / "rrq-py" / "rrq" / "bin" / "rrq",
         repo_root / "rrq-rs" / "target" / "release" / "rrq",
         repo_root / "rrq-rs" / "target" / "debug" / "rrq",
+        repo_root / "rrq-py" / "rrq" / "bin" / "rrq",
     ]
     for candidate in repo_candidates:
         if candidate.exists():
             return [str(candidate)]
+
+    rrq_path = shutil.which("rrq")
+    if rrq_path:
+        return [rrq_path]
 
     raise SystemExit(
         "rrq CLI not found on PATH. Install it via `pip install rrq` or "
@@ -317,7 +317,7 @@ def main() -> int:
         default=os.getenv("RRQ_REDIS_DSN", "redis://localhost:6379/3"),
         help="Redis DSN (default: redis://localhost:6379/3)",
     )
-    parser.add_argument("--count", type=int, default=1000, help="Job count per run")
+    parser.add_argument("--count", type=int, default=100, help="Job count per run")
     parser.add_argument(
         "--timeout",
         type=float,

--- a/examples/python/handlers.py
+++ b/examples/python/handlers.py
@@ -11,8 +11,8 @@ from rrq.runner import ExecutionRequest
 
 async def quick_task(request: ExecutionRequest) -> dict[str, Any]:
     await asyncio.sleep(0.05)
-    message = request.args[0] if request.args else None
-    source = request.kwargs.get("source") if request.kwargs else None
+    message = request.params.get("message")
+    source = request.params.get("source")
     return {
         "message": message,
         "job_id": request.context.job_id,
@@ -21,9 +21,7 @@ async def quick_task(request: ExecutionRequest) -> dict[str, Any]:
 
 
 async def slow_task(request: ExecutionRequest) -> dict[str, Any]:
-    seconds = 1.0
-    if request.args:
-        seconds = float(request.args[0])
+    seconds = float(request.params.get("seconds", 1.0))
     await asyncio.sleep(seconds)
     return {"slept": seconds, "job_id": request.context.job_id}
 
@@ -33,9 +31,7 @@ async def error_task(request: ExecutionRequest) -> None:
 
 
 async def retry_task(request: ExecutionRequest) -> dict[str, Any]:
-    until_attempt = 2
-    if request.args:
-        until_attempt = int(request.args[0])
+    until_attempt = int(request.params.get("until_attempt", 2))
     if request.context.attempt < until_attempt:
         raise RetryJob("retry requested", defer_seconds=0.2)
     return {

--- a/examples/python/producer.py
+++ b/examples/python/producer.py
@@ -35,14 +35,20 @@ async def main() -> None:
 
     try:
         for i in range(args.count):
-            await client.enqueue("quick_task", {"args": [f"msg-{i}"]})
-        await client.enqueue("slow_task", {"args": [1.0]})
+            await client.enqueue(
+                "quick_task",
+                {"params": {"message": f"msg-{i}", "source": "python"}},
+            )
+        await client.enqueue("slow_task", {"params": {"seconds": 1.0}})
         await client.enqueue("error_task", {})
-        await client.enqueue("retry_task", {"args": [2]})
+        await client.enqueue("retry_task", {"params": {"until_attempt": 2}})
 
         rust_count = args.rust_count or (1 if args.include_rust else 0)
         for i in range(rust_count):
-            await client.enqueue("rust#echo", {"kwargs": {"hello": f"from python {i}"}})
+            await client.enqueue(
+                "rust#echo",
+                {"params": {"hello": f"from python {i}"}},
+            )
     finally:
         await client.close()
 

--- a/examples/rust/producer/Cargo.lock
+++ b/examples/rust/producer/Cargo.lock
@@ -262,6 +262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +483,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,12 +601,13 @@ dependencies = [
 
 [[package]]
 name = "rrq-config"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "chrono",
  "cron",
  "dotenvy",
+ "num_cpus",
  "serde",
  "serde_json",
  "toml",
@@ -598,7 +615,7 @@ dependencies = [
 
 [[package]]
 name = "rrq-producer"
-version = "0.9.9"
+version = "0.9.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/rust/producer/src/main.rs
+++ b/examples/rust/producer/src/main.rs
@@ -4,11 +4,10 @@ use serde_json::{json, Map, Value};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let redis_dsn = std::env::var("RRQ_REDIS_DSN")
-        .unwrap_or_else(|_| "redis://localhost:6379/3".to_string());
+    let redis_dsn =
+        std::env::var("RRQ_REDIS_DSN").unwrap_or_else(|_| "redis://localhost:6379/3".to_string());
     let queue_name = std::env::var("RRQ_QUEUE").unwrap_or_else(|_| "default".to_string());
-    let function_name =
-        std::env::var("RRQ_FUNCTION").unwrap_or_else(|_| "quick_task".to_string());
+    let function_name = std::env::var("RRQ_FUNCTION").unwrap_or_else(|_| "quick_task".to_string());
     let count: usize = std::env::var("RRQ_COUNT")
         .ok()
         .and_then(|val| val.parse().ok())
@@ -17,15 +16,14 @@ async fn main() -> Result<()> {
     let producer = Producer::new(redis_dsn).await?;
 
     for i in 0..count {
-        let args = vec![json!(format!("from-rust-{i}"))];
-        let mut kwargs: Map<String, Value> = Map::new();
-        kwargs.insert("source".to_string(), json!("rust"));
+        let mut params: Map<String, Value> = Map::new();
+        params.insert("message".to_string(), json!(format!("from-rust-{i}")));
+        params.insert("source".to_string(), json!("rust"));
 
         producer
             .enqueue(
                 &function_name,
-                args,
-                kwargs,
+                params,
                 EnqueueOptions {
                     queue_name: Some(queue_name.clone()),
                     ..Default::default()

--- a/rrq-py/README.md
+++ b/rrq-py/README.md
@@ -1,133 +1,131 @@
 # RRQ: Reliable Redis Queue
 
-RRQ is a Redis-backed job queue **system** with a Rust orchestrator and a
-language-agnostic runner protocol. Producers can enqueue jobs from Python,
-Rust, or any language that can write the job schema to Redis. Runners can be
-written in any language that can speak the socket protocol.
+[![PyPI](https://img.shields.io/pypi/v/rrq.svg)](https://pypi.org/project/rrq/)
+[![License](https://img.shields.io/pypi/l/rrq.svg)](LICENSE)
 
-This Python package (`rrq`) provides the producer SDK plus the Python runner
-runtime. The Rust components are published as crates and are typically used to
-run the orchestrator or build native producers/runners.
+**RRQ is a distributed job queue that actually works.** It combines a Rust-powered orchestrator with language-native workers to give you the reliability of battle-tested infrastructure with the flexibility of writing job handlers in Python, TypeScript, or Rust.
 
-## Project Components
+## Why RRQ?
 
-- **Python package (this)**: producer SDK, Python runner runtime, OpenTelemetry
-  runner integration.
-- **Rust orchestrator (`rrq` crate)**: scheduling, retries, timeouts, DLQ, cron.
-- **Rust producer (`rrq-producer` crate)**: native producer for Rust apps.
-- **Rust runner (`rrq-runner` crate)**: runner runtime + example.
+Most job queues make you choose: either fight with complex distributed systems concepts, or accept unreliable "good enough" solutions. RRQ takes a different approach:
 
-## Architecture
+- **Rust orchestrator, any-language workers** - The hard parts (scheduling, retries, locking, timeouts) are handled by a single-binary Rust process. Your job handlers are just normal async functions in your preferred language.
+
+- **Redis as the source of truth** - No separate databases to manage. Jobs, queues, locks, and results all live in Redis with atomic operations and predictable semantics.
+
+- **Production-grade features built in** - Retry policies, dead letter queues, job timeouts, cron scheduling, distributed tracing, and health checks work out of the box.
+
+- **Fast and lightweight** - The Rust orchestrator handles thousands of jobs per second with minimal memory. Workers are isolated processes that can be scaled independently.
+
+## How It Works
 
 ```
 ┌──────────────────────────────┐
-│        Producers SDKs        │
-│  (Python, Rust, other langs) │
+│     Your Application         │
+│  (Python, TypeScript, Rust)  │
+│                              │
+│   client.enqueue("job", {})  │
 └───────────────┬──────────────┘
                 │ enqueue jobs
                 ▼
       ┌───────────────────────┐
       │         Redis         │
-      │  - queues (ZSETs)     │
-      │  - job hashes         │
-      │  - locks              │
-      │  - DLQ lists          │
+      │  queues, jobs, locks  │
       └──────────┬────────────┘
-                 │ poll/lock
+                 │ poll/dispatch
                  ▼
       ┌──────────────────────────────┐
-      │   Rust RRQ Orchestrator      │
-      │     (rrq worker run)         │
-      │ - scheduling + retries       │
-      │ - timeouts + DLQ             │
-      │ - queue routing              │
-      │ - cron jobs                  │
+      │     RRQ Orchestrator         │
+      │   (single Rust binary)       │
+      │ • scheduling & retries       │
+      │ • timeouts & deadlines       │
+      │ • dead letter queue          │
+      │ • cron jobs                  │
       └──────────┬───────────────────┘
-                 │ TCP socket protocol
-                 │ (request <-> outcome)
+                 │ socket protocol
                  ▼
-   ┌─────────────────────┬─────────────────────┐
-   │ Python Runner     │ Rust/Other Runner │
-   │ (rrq-runner)      │ (rrq-runner)      │
-   └───────────────────────────────────────────┘
+   ┌─────────────────────────────────────────┐
+   │              Job Runners                 │
+   │  ┌─────────────┐    ┌─────────────┐     │
+   │  │   Python    │    │ TypeScript  │     │
+   │  │   Worker    │    │   Worker    │     │
+   │  └─────────────┘    └─────────────┘     │
+   └─────────────────────────────────────────┘
 ```
 
-Runners return outcomes to the orchestrator; the orchestrator persists job
-state/results back to Redis.
+## This Package
 
-## Requirements
+This Python package (`rrq`) gives you everything you need to work with RRQ from Python:
 
-- Python 3.11+ (producer + Python runner runtime)
-- Rust `rrq` binary (orchestrator CLI; bundled in wheels or provided separately)
-- Redis 5.0+
+- **Producer client** - Enqueue jobs from your Python application
+- **Runner runtime** - Execute job handlers written in Python
+- **OpenTelemetry integration** - Distributed tracing from producer to runner
 
-If you ship the Rust binary separately, set `RRQ_RUST_BIN` to its path.
+The Rust orchestrator binary is bundled in the wheel, so there's nothing else to install.
 
-### FFI producer library (local dev/tests)
+## Quick Start
 
-The Python producer uses the Rust `rrq-producer` shared library. For local
-tests from the repo, use the helper script to build the library and set
-`RRQ_PRODUCER_LIB_PATH` automatically:
+### 1. Install
 
 ```bash
-sh scripts/with-producer-lib.sh -- sh -c "cd rrq-py && uv run pytest"
-```
-
-Published wheels include `rrq/bin/librrq_producer.*` so no extra setup is
-required in production unless you want to override the library path.
-
-## Quickstart
-
-### 1) Install
-
-```
+pip install rrq
+# or
 uv pip install rrq
 ```
 
-### 2) Create `rrq.toml`
+### 2. Create configuration (`rrq.toml`)
 
 ```toml
 [rrq]
-redis_dsn = "redis://localhost:6379/1"
+redis_dsn = "redis://localhost:6379/0"
 default_runner_name = "python"
 
 [rrq.runners.python]
 type = "socket"
-cmd = ["rrq-runner", "--settings", "myapp.runner_config.python_runner_settings"]
-# Required: localhost TCP socket (host:port). For pool_size > 1, ports increment.
+cmd = ["rrq-runner", "--settings", "myapp.runner:settings"]
 tcp_socket = "127.0.0.1:9000"
 ```
 
-### 3) Register Python handlers
+### 3. Write a job handler
 
 ```python
-# runner_config.py
+# myapp/handlers.py
+from rrq.runner import ExecutionRequest
+
+async def send_welcome_email(request: ExecutionRequest):
+    user_email = request.params.get("email")
+    template = request.params.get("template", "welcome")
+
+    # Your email sending logic here
+    await send_email(to=user_email, template=template)
+
+    return {"sent": True, "email": user_email}
+```
+
+### 4. Register handlers
+
+```python
+# myapp/runner.py
 from rrq.runner_settings import PythonRunnerSettings
 from rrq.registry import Registry
-
-from . import handlers
+from myapp import handlers
 
 registry = Registry()
-registry.register("process_message", handlers.process_message)
+registry.register("send_welcome_email", handlers.send_welcome_email)
 
-python_runner_settings = PythonRunnerSettings(
-    registry=registry,
-)
+settings = PythonRunnerSettings(registry=registry)
 ```
 
-### 4) Run the Python runner
+### 5. Start the system
 
-```
-rrq-runner --settings myapp.runner_config.python_runner_settings
-```
-
-### 5) Run the Rust orchestrator
-
-```
+```bash
+# Terminal 1: Start the orchestrator (runs runners automatically)
 rrq worker run --config rrq.toml
+
+# That's it! The orchestrator spawns and manages your Python runners.
 ```
 
-### 6) Enqueue jobs (Python)
+### 6. Enqueue jobs
 
 ```python
 import asyncio
@@ -135,126 +133,142 @@ from rrq.client import RRQClient
 
 async def main():
     client = RRQClient(config_path="rrq.toml")
-    await client.enqueue("process_message", {"args": ["hello"]})
+
+    job_id = await client.enqueue("send_welcome_email", {
+        "email": "user@example.com",
+        "template": "welcome"
+    })
+
+    print(f"Enqueued job: {job_id}")
     await client.close()
 
 asyncio.run(main())
 ```
 
-### Job status + results
+## Features
+
+### Scheduled Jobs
+
+Delay job execution:
 
 ```python
-status = await client.get_job_status(job_id)
+# Run in 5 minutes
+await client.enqueue("cleanup", {}, defer_by_seconds=300)
+
+# Run at a specific time
+from datetime import datetime, timezone
+await client.enqueue("report", {}, defer_until=datetime(2024, 1, 1, 9, 0, tzinfo=timezone.utc))
 ```
 
-### OpenTelemetry (runner)
+### Unique Jobs (Idempotency)
+
+Prevent duplicate jobs:
 
 ```python
-from rrq.integrations import otel
-
-otel.enable(service_name="my-runner")
+# Only one job with this key will be enqueued
+await client.enqueue_with_unique_key(
+    "process_order",
+    unique_key="order-123",
+    kwargs={"order_id": "123"}
+)
 ```
 
-See `docs/TELEMETRY.md` for end-to-end tracing from producer → runner.
+### Rate Limiting
 
-## Configuration
+Limit how often a job can run:
 
-`rrq.toml` is the source of truth for the orchestrator and runners. Key areas:
+```python
+job_id = await client.enqueue_with_rate_limit(
+    "sync_user",
+    kwargs={"user_id": "456"},
+    rate_limit_key="user-456",
+    rate_limit_seconds=60
+)
+if job_id is None:
+    print("Rate limited, try again later")
+```
 
-- `[rrq]` basic settings (Redis, retries, timeouts, poll delay)
-- `[rrq.runners.<name>]` runner commands, pool sizes, and
-  `max_in_flight`
-- `[rrq.runner_routes]` queue → runner mapping (legacy `[rrq.routing]` still
-  accepted)
-- `[[rrq.cron_jobs]]` periodic scheduling
-- `[rrq.watch]` watch mode defaults (path/patterns)
+### Debouncing
 
-See `docs/CONFIG_REFERENCE.md` for the full TOML schema,
-`docs/CLI_REFERENCE.md` for CLI details, and `docs/RUNNER_PROTOCOL.md` for
-wire format.
+Delay and deduplicate rapid job submissions:
 
-## Cron Jobs (rrq.toml)
+```python
+# Only the last enqueue within the window will execute
+await client.enqueue_with_debounce(
+    "save_document",
+    kwargs={"doc_id": "789"},
+    debounce_key="doc-789",
+    debounce_seconds=5
+)
+```
 
-Use `[[rrq.cron_jobs]]` entries to enqueue periodic jobs while a worker is
-running. Schedules are evaluated in UTC.
+### Cron Jobs
+
+Schedule recurring jobs in `rrq.toml`:
 
 ```toml
 [[rrq.cron_jobs]]
-function_name = "process_message"
-schedule = "0 * * * * *"
-args = ["cron payload"]
-kwargs = { source = "cron" }
-queue_name = "default"
-unique = true
+function_name = "daily_report"
+schedule = "0 0 9 * * *"  # 9 AM daily (6-field cron with seconds)
+queue_name = "scheduled"
 ```
 
-Fields:
-- `function_name` (required): Handler name to enqueue.
-- `schedule` (required): Cron expression with seconds (6-field format).
-- `args` / `kwargs`: Optional arguments passed to the handler.
-- `queue_name`: Optional override for the target queue.
-- `unique`: Optional; uses a per-function unique lock to prevent duplicates.
+### Job Status
 
-## CLI Overview (Rust `rrq`)
+Check job progress:
 
-- `rrq worker run`, `rrq worker watch`
-- `rrq check`
-- `rrq queue list|stats|inspect`
-- `rrq job show|list|trace|replay|cancel`
-- `rrq dlq list|stats|inspect|requeue`
-- `rrq debug generate-jobs|generate-workers|submit|clear|stress-test`
+```python
+status = await client.get_job_status(job_id)
+print(f"Status: {status}")
+```
 
-## Worker Watch Mode
+### OpenTelemetry
 
-`rrq worker watch` runs a normal worker loop plus a filesystem watcher. It
-watches a path recursively and normalizes change paths before matching include
-globs (default `*.py`, `*.toml`) and ignore globs. A matching change triggers a
-graceful worker shutdown, closes runners, and starts a fresh worker. Watch
-mode is intended for local development; runner pool sizes and
-`max_in_flight` are forced to 1 to keep restarts lightweight. It also respects
-`.gitignore` and `.git/info/exclude` by default; disable with `--no-gitignore`.
+Enable distributed tracing:
 
-You can also configure watch defaults in `rrq.toml`:
+```python
+from rrq.integrations import otel
+otel.enable(service_name="my-service")
+```
+
+Traces propagate from producer → orchestrator → runner automatically.
+
+## Configuration Reference
+
+See [docs/CONFIG_REFERENCE.md](docs/CONFIG_REFERENCE.md) for the full TOML schema.
+
+Key settings:
 
 ```toml
-[rrq.watch]
-path = "."
-include_patterns = ["*.py", "*.toml"]
-ignore_patterns = [".venv/**", "dist/**"]
-no_gitignore = false
+[rrq]
+redis_dsn = "redis://localhost:6379/0"
+default_runner_name = "python"
+default_job_timeout_seconds = 300  # 5 minutes
+default_max_retries = 3
+
+[rrq.runners.python]
+type = "socket"
+cmd = ["rrq-runner", "--settings", "myapp.runner:settings"]
+tcp_socket = "127.0.0.1:9000"
+pool_size = 4           # Number of runner processes
+max_in_flight = 10      # Concurrent jobs per runner
 ```
 
-## Runner Logs
+## Related Packages
 
-Runners can emit logs to stdout/stderr. The orchestrator captures these lines
-and emits them with runner prefixes. Structured logging is not part of the
-wire protocol.
+| Package | Language | Purpose |
+|---------|----------|---------|
+| [rrq](https://pypi.org/project/rrq/) | Python | Producer client + runner (this package) |
+| [rrq-ts](https://www.npmjs.com/package/rrq-ts) | TypeScript | Producer client + runner |
+| [rrq](https://crates.io/crates/rrq) | Rust | Orchestrator binary |
+| [rrq-producer](https://crates.io/crates/rrq-producer) | Rust | Native producer client |
+| [rrq-runner](https://crates.io/crates/rrq-runner) | Rust | Native runner runtime |
 
-## Testing
+## Requirements
 
-Runtime-only Python tests (producer + runner + store):
+- Python 3.11+
+- Redis 5.0+
 
-```
-cd rrq-py
-uv run pytest
-```
+## License
 
-End-to-end integration (Python-only, Rust-only, mixed):
-
-```
-cd rrq-py
-uv run python ../examples/integration_test.py
-```
-
-## Reference Implementations
-
-- Rust orchestrator (crate `rrq`): `rrq-rs/orchestrator`
-- Rust producer: `rrq-rs/producer`
-- Rust runner: `rrq-rs/runner`
-- Protocol types: `rrq-rs/protocol`
-- Python runner examples: `examples/python/`
-
-## Telemetry
-
-Optional tracing integrations are available for Python producers and the Python
-runner runtime. See `rrq/integrations/`.
+Apache-2.0

--- a/rrq-py/rrq/client.py
+++ b/rrq-py/rrq/client.py
@@ -60,8 +60,7 @@ class RRQClient:
         options: dict[str, Any] | None = None,
     ) -> str:
         options = dict(options) if options else {}
-        args = list(options.pop("args", []))
-        kwargs = dict(options.pop("kwargs", {}))
+        params = dict(options.pop("params", {}))
 
         defer_until = options.get("defer_until")
         if isinstance(defer_until, datetime):
@@ -69,8 +68,7 @@ class RRQClient:
 
         request = {
             "function_name": function_name,
-            "args": args,
-            "kwargs": kwargs,
+            "params": params,
             "options": options,
         }
 
@@ -102,8 +100,7 @@ class RRQClient:
         merged = dict(options)
         request = {
             "function_name": function_name,
-            "args": list(merged.pop("args", [])),
-            "kwargs": dict(merged.pop("kwargs", {})),
+            "params": dict(merged.pop("params", {})),
             "options": merged,
             "mode": "rate_limit",
         }
@@ -121,8 +118,7 @@ class RRQClient:
         merged = dict(options)
         request = {
             "function_name": function_name,
-            "args": list(merged.pop("args", [])),
-            "kwargs": dict(merged.pop("kwargs", {})),
+            "params": dict(merged.pop("params", {})),
             "options": merged,
             "mode": "debounce",
         }

--- a/rrq-py/rrq/producer_ffi.py
+++ b/rrq-py/rrq/producer_ffi.py
@@ -75,8 +75,7 @@ class EnqueueRequestModel(BaseModel):
         None
     )
     function_name: str = Field(min_length=1)
-    args: list[Any] = Field(default_factory=list)
-    kwargs: dict[str, Any] = Field(default_factory=dict)
+    params: dict[str, Any] = Field(default_factory=dict)
     options: EnqueueOptionsModel | None = None
 
 

--- a/rrq-py/rrq/runner.py
+++ b/rrq-py/rrq/runner.py
@@ -115,6 +115,10 @@ class PythonRunner:
                     "Handler for job %s returned successfully.", request.job_id
                 )
                 if isinstance(result, ExecutionOutcome):
+                    if not result.job_id:
+                        result.job_id = request.job_id
+                    if not result.request_id:
+                        result.request_id = request.request_id
                     span.success(duration_seconds=time.monotonic() - start_time)
                     return result
                 span.success(duration_seconds=time.monotonic() - start_time)

--- a/rrq-py/rrq/runner.py
+++ b/rrq-py/rrq/runner.py
@@ -32,12 +32,11 @@ class ExecutionContext(BaseModel):
 class ExecutionRequest(BaseModel):
     """Job data sent to an runner."""
 
-    protocol_version: str = "1"
+    protocol_version: str = "2"
     request_id: str
     job_id: str
     function_name: str
-    args: list[Any] = Field(default_factory=list)
-    kwargs: dict[str, Any] = Field(default_factory=dict)
+    params: dict[str, Any] = Field(default_factory=dict)
     context: ExecutionContext
 
 

--- a/rrq-py/rrq/runner_runtime.py
+++ b/rrq-py/rrq/runner_runtime.py
@@ -28,7 +28,7 @@ MAX_IN_FLIGHT_PER_CONNECTION = 64
 
 
 class CancelRequest(BaseModel):
-    protocol_version: str = "1"
+    protocol_version: str = "2"
     job_id: str
     request_id: str | None = None
     hard_kill: bool = Field(default=False)
@@ -324,7 +324,7 @@ async def _handle_connection(
             if message_type == "request":
                 request = ExecutionRequest.model_validate(payload)
 
-                if request.protocol_version != "1":
+                if request.protocol_version != "2":
                     outcome = ExecutionOutcome(
                         job_id=request.job_id,
                         request_id=request.request_id,
@@ -371,7 +371,7 @@ async def _handle_connection(
 
             if message_type == "cancel":
                 cancel_request = CancelRequest.model_validate(payload)
-                if cancel_request.protocol_version != "1":
+                if cancel_request.protocol_version != "2":
                     continue
                 request_id = cancel_request.request_id
                 if request_id is None:

--- a/rrq-py/tests/test_client.py
+++ b/rrq-py/tests/test_client.py
@@ -55,11 +55,10 @@ async def test_enqueue_job_writes_job_and_queue(
     rrq_client: RRQClient, redis_for_client_tests: AsyncRedis
 ) -> None:
     func_name = "test_function_client"
-    args_ = [1, "hello"]
 
     job_id = await rrq_client.enqueue(
         func_name,
-        {"args": args_, "kwargs": {"world": True}},
+        {"params": {"a": 1, "b": "hello", "world": True}},
     )
 
     job_key = f"{JOB_KEY_PREFIX}{job_id}"
@@ -164,7 +163,7 @@ async def test_enqueue_with_user_specified_job_id(
 
     with pytest.raises(ValueError):
         await rrq_client.enqueue(
-            func_name, {"job_id": user_job_id, "args": ["new_arg"]}
+            func_name, {"job_id": user_job_id, "params": {"new_arg": 1}}
         )
 
 
@@ -206,7 +205,7 @@ async def test_enqueue_with_unique_key_idempotent(
     assert idempotency_value is not None
 
     job2 = await rrq_client.enqueue(
-        func_name, {"unique_key": unique_key, "args": ["different_arg"]}
+        func_name, {"unique_key": unique_key, "params": {"different_arg": 1}}
     )
     assert job2 == job1
 

--- a/rrq-py/tests/test_runner.py
+++ b/rrq-py/tests/test_runner.py
@@ -28,8 +28,7 @@ async def test_python_runner_context_includes_trace_and_deadline() -> None:
         request_id="req-ctx",
         job_id="job-ctx",
         function_name="echo",
-        args=[],
-        kwargs={},
+        params={},
         context=ExecutionContext(
             job_id="job-ctx",
             attempt=2,

--- a/rrq-py/tests/test_runner_runtime.py
+++ b/rrq-py/tests/test_runner_runtime.py
@@ -37,8 +37,7 @@ async def test_execute_with_deadline_allows_future_deadline() -> None:
         request_id="req-deadline",
         job_id="job-deadline",
         function_name="echo",
-        args=[],
-        kwargs={},
+        params={},
         context=ExecutionContext(
             job_id="job-deadline",
             attempt=1,
@@ -70,8 +69,7 @@ async def test_execute_with_deadline_raises_for_past_deadline() -> None:
         request_id="req-expired",
         job_id="job-expired",
         function_name="echo",
-        args=[],
-        kwargs={},
+        params={},
         context=ExecutionContext(
             job_id="job-expired",
             attempt=1,
@@ -290,7 +288,7 @@ async def test_cancel_by_job_id_cancels_all_requests() -> None:
         await asyncio.wait_for(wait_for_tracking(), timeout=1)
 
         cancel_payload = {
-            "protocol_version": "1",
+            "protocol_version": "2",
             "job_id": job_id,
             "request_id": None,
             "hard_kill": False,
@@ -344,8 +342,7 @@ async def test_execute_and_respond_cleans_inflight_on_write_error(
         request_id="req-write-error",
         job_id="job-write-error",
         function_name="echo",
-        args=[],
-        kwargs={},
+        params={},
         context=ExecutionContext(
             job_id="job-write-error",
             attempt=1,

--- a/rrq-py/tests/test_runner_runtime.py
+++ b/rrq-py/tests/test_runner_runtime.py
@@ -112,8 +112,7 @@ async def test_handle_connection_processes_request() -> None:
             request_id="req-ready",
             job_id="job-ready",
             function_name="echo",
-            args=[],
-            kwargs={},
+            params={},
             context=ExecutionContext(
                 job_id="job-ready",
                 attempt=1,
@@ -171,8 +170,7 @@ async def test_handle_connection_returns_busy_when_inflight_limit_reached(
             request_id="req-1",
             job_id=job_id,
             function_name="block",
-            args=[],
-            kwargs={},
+            params={},
             context=ExecutionContext(
                 job_id=job_id,
                 attempt=1,
@@ -184,8 +182,7 @@ async def test_handle_connection_returns_busy_when_inflight_limit_reached(
             request_id="req-2",
             job_id=job_id,
             function_name="block",
-            args=[],
-            kwargs={},
+            params={},
             context=ExecutionContext(
                 job_id=job_id,
                 attempt=1,
@@ -254,8 +251,7 @@ async def test_cancel_by_job_id_cancels_all_requests() -> None:
             request_id="req-1",
             job_id=job_id,
             function_name="block",
-            args=[],
-            kwargs={},
+            params={},
             context=ExecutionContext(
                 job_id=job_id,
                 attempt=1,
@@ -267,8 +263,7 @@ async def test_cancel_by_job_id_cancels_all_requests() -> None:
             request_id="req-2",
             job_id=job_id,
             function_name="block",
-            args=[],
-            kwargs={},
+            params={},
             context=ExecutionContext(
                 job_id=job_id,
                 attempt=2,

--- a/rrq-rs/Cargo.lock
+++ b/rrq-rs/Cargo.lock
@@ -1350,6 +1350,7 @@ dependencies = [
  "chrono",
  "cron",
  "dotenvy",
+ "num_cpus",
  "serde",
  "serde_json",
  "tempfile",

--- a/rrq-rs/README.md
+++ b/rrq-rs/README.md
@@ -1,34 +1,102 @@
-# Rust reference implementation
+# RRQ Rust Workspace
 
-This directory is a Cargo workspace containing:
+This is the Rust implementation of RRQ (Reliable Redis Queue), providing the orchestrator, producer, runner, and protocol crates.
 
-- `rrq-config`: TOML loader + settings types shared by all components
-- `rrq-protocol`: shared protocol types for runners
-- `rrq-producer`: minimal producer that writes jobs to Redis
-- `rrq-runner`: runner reference implementation
-- `rrq` (in `orchestrator/`): Rust scheduler/orchestrator (worker) implementation
+## What is RRQ?
 
-## Git dependency example
+RRQ is a distributed job queue that separates concerns cleanly: a Rust orchestrator handles all the complex distributed systems logic (scheduling, retries, locking, timeouts) while job handlers run in isolated processes using any language.
+
+**Key benefits:**
+- **Redis-backed** - Atomic operations, predictable semantics, no separate database
+- **Language-agnostic workers** - Write handlers in Python, TypeScript, or Rust
+- **Production-ready** - Retries, DLQ, timeouts, cron, distributed tracing out of the box
+- **Fast and lightweight** - Thousands of jobs/second with minimal memory
+
+## Crates
+
+| Crate | Description | crates.io |
+|-------|-------------|-----------|
+| [`rrq`](./orchestrator) | CLI orchestrator - schedules jobs, manages runners, handles retries | [![Crates.io](https://img.shields.io/crates/v/rrq.svg)](https://crates.io/crates/rrq) |
+| [`rrq-producer`](./producer) | Client library for enqueuing jobs | [![Crates.io](https://img.shields.io/crates/v/rrq-producer.svg)](https://crates.io/crates/rrq-producer) |
+| [`rrq-runner`](./runner) | Runtime for building job handlers in Rust | [![Crates.io](https://img.shields.io/crates/v/rrq-runner.svg)](https://crates.io/crates/rrq-runner) |
+| [`rrq-protocol`](./protocol) | Wire protocol types for orchestrator-runner communication | [![Crates.io](https://img.shields.io/crates/v/rrq-protocol.svg)](https://crates.io/crates/rrq-protocol) |
+| [`rrq-config`](./config) | Configuration loader and settings types | [![Crates.io](https://img.shields.io/crates/v/rrq-config.svg)](https://crates.io/crates/rrq-config) |
+
+## Quick Start
+
+### Install the orchestrator
+
+```bash
+cargo install rrq
+```
+
+### Run a worker
+
+```bash
+rrq worker run --config rrq.toml
+```
+
+### Configuration (`rrq.toml`)
+
+```toml
+[rrq]
+redis_dsn = "redis://localhost:6379/0"
+default_runner_name = "python"
+
+[rrq.runners.python]
+type = "socket"
+cmd = ["rrq-runner", "--settings", "myapp.runner:settings"]
+tcp_socket = "127.0.0.1:9000"
+pool_size = 4
+max_in_flight = 10
+```
+
+## Using as Dependencies
+
+Add crates via git:
 
 ```toml
 [dependencies]
-rrq-protocol = { git = "https://github.com/getresq/rrq", package = "rrq-protocol", rev = "<sha>" }
-rrq-config = { git = "https://github.com/getresq/rrq", package = "rrq-config", rev = "<sha>" }
-rrq-producer = { git = "https://github.com/getresq/rrq", package = "rrq-producer", rev = "<sha>" }
+rrq-producer = { git = "https://github.com/getresq/rrq", package = "rrq-producer" }
+rrq-protocol = { git = "https://github.com/getresq/rrq", package = "rrq-protocol" }
 ```
 
-## Runner example
+Or from crates.io:
 
+```toml
+[dependencies]
+rrq-producer = "0.9"
+rrq-runner = "0.9"
 ```
-cd rrq-rs/runner
+
+## Building from Source
+
+```bash
+# Build all crates
+cargo build --release
+
+# Run tests
+cargo test
+
+# Build the orchestrator binary
+cargo build -p rrq --release
+# Binary at ./target/release/rrq
+```
+
+## Example: Rust Runner
+
+```bash
+cd runner
 RRQ_RUNNER_TCP_SOCKET=127.0.0.1:9000 cargo run --example socket_runner
 ```
 
-## Tests
+## Related Packages
 
-Run the workspace tests:
+| Package | Language | Purpose |
+|---------|----------|---------|
+| [rrq](https://pypi.org/project/rrq/) | Python | Producer client + runner |
+| [rrq-ts](https://www.npmjs.com/package/rrq-ts) | TypeScript | Producer client + runner |
 
-```
-cd rrq-rs
-cargo test
-```
+## License
+
+Apache-2.0

--- a/rrq-rs/config/Cargo.toml
+++ b/rrq-rs/config/Cargo.toml
@@ -19,6 +19,7 @@ dotenvy = "0.15.7"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 toml = "0.9.11"
+num_cpus = "1.17.0"
 
 [dev-dependencies]
 tempfile = "3.17.1"

--- a/rrq-rs/config/README.md
+++ b/rrq-rs/config/README.md
@@ -1,26 +1,88 @@
 # rrq-config
 
-Shared configuration loader and settings types for RRQ.
+[![Crates.io](https://img.shields.io/crates/v/rrq-config.svg)](https://crates.io/crates/rrq-config)
+[![Documentation](https://docs.rs/rrq-config/badge.svg)](https://docs.rs/rrq-config)
+[![License](https://img.shields.io/crates/l/rrq-config.svg)](LICENSE)
 
-This crate is used by the Rust orchestrator and by the FFI producer bindings to
-ensure consistent config parsing and defaults across languages.
+**Configuration loader and settings types for RRQ.**
+
+## What is RRQ?
+
+RRQ (Reliable Redis Queue) is a distributed job queue with a Rust orchestrator. This crate provides shared configuration parsing for the orchestrator, producer, and FFI bindings.
+
+## When to Use This Crate
+
+Use `rrq-config` if you're:
+- Building custom tooling that reads `rrq.toml`
+- Extending the RRQ configuration format
+- Embedding RRQ components with programmatic config
+
+For most use cases, the configuration is loaded automatically by [`rrq`](https://crates.io/crates/rrq), [`rrq-producer`](https://crates.io/crates/rrq-producer), etc.
+
+## Installation
+
+```toml
+[dependencies]
+rrq-config = "0.9"
+```
 
 ## Usage
+
+### Load from file
 
 ```rust
 use rrq_config::load_toml_settings;
 
-let settings = load_toml_settings(None)?;
-println!("Redis DSN: {}", settings.redis_dsn);
+let settings = load_toml_settings(Some("rrq.toml"))?;
+println!("Redis: {}", settings.redis_dsn);
+println!("Default runner: {:?}", settings.default_runner_name);
 ```
 
-## Producer settings
+### Load producer settings
 
 ```rust
 use rrq_config::load_producer_settings;
 
-let producer_settings = load_producer_settings(None)?;
+let producer_settings = load_producer_settings(Some("rrq.toml"))?;
+println!("Queue: {}", producer_settings.queue_name);
 ```
+
+### Default config path
+
+```rust
+use rrq_config::load_toml_settings;
+
+// Looks for RRQ_CONFIG env var, then ./rrq.toml
+let settings = load_toml_settings(None)?;
+```
+
+## Configuration Format
+
+```toml
+[rrq]
+redis_dsn = "redis://localhost:6379/0"
+default_runner_name = "python"
+default_job_timeout_seconds = 300
+default_max_retries = 3
+
+[rrq.runners.python]
+type = "socket"
+cmd = ["rrq-runner", "--settings", "myapp.runner:settings"]
+tcp_socket = "127.0.0.1:9000"
+pool_size = 4
+max_in_flight = 10
+
+[[rrq.cron_jobs]]
+function_name = "cleanup"
+schedule = "0 0 * * * *"
+```
+
+## Related Crates
+
+| Crate | Purpose |
+|-------|---------|
+| [`rrq`](https://crates.io/crates/rrq) | Orchestrator |
+| [`rrq-producer`](https://crates.io/crates/rrq-producer) | Job producer |
 
 ## License
 

--- a/rrq-rs/config/src/cron.rs
+++ b/rrq-rs/config/src/cron.rs
@@ -12,9 +12,7 @@ pub struct CronJob {
     pub function_name: String,
     pub schedule: String,
     #[serde(default)]
-    pub args: Vec<Value>,
-    #[serde(default)]
-    pub kwargs: serde_json::Map<String, Value>,
+    pub params: serde_json::Map<String, Value>,
     #[serde(default)]
     pub queue_name: Option<String>,
     #[serde(default)]
@@ -59,8 +57,7 @@ mod tests {
         let mut job = CronJob {
             function_name: "task".to_string(),
             schedule: "0 * * * * *".to_string(),
-            args: vec![],
-            kwargs: serde_json::Map::new(),
+            params: serde_json::Map::new(),
             queue_name: None,
             unique: false,
             next_run_time: None,
@@ -79,8 +76,7 @@ mod tests {
         let mut job = CronJob {
             function_name: "task".to_string(),
             schedule: "0 * * * * *".to_string(),
-            args: vec![],
-            kwargs: serde_json::Map::new(),
+            params: serde_json::Map::new(),
             queue_name: None,
             unique: false,
             next_run_time: None,
@@ -98,8 +94,7 @@ mod tests {
         let mut job = CronJob {
             function_name: "task".to_string(),
             schedule: "nope".to_string(),
-            args: vec![],
-            kwargs: serde_json::Map::new(),
+            params: serde_json::Map::new(),
             queue_name: None,
             unique: false,
             next_run_time: None,

--- a/rrq-rs/orchestrator/src/client.rs
+++ b/rrq-rs/orchestrator/src/client.rs
@@ -36,8 +36,7 @@ impl RRQClient {
     pub async fn enqueue(
         &mut self,
         function_name: &str,
-        args: Vec<Value>,
-        kwargs: serde_json::Map<String, Value>,
+        params: serde_json::Map<String, Value>,
         options: EnqueueOptions,
     ) -> Result<Job> {
         let job_id = options.job_id.unwrap_or_else(Job::new_id);
@@ -114,8 +113,7 @@ impl RRQClient {
         let job = Job {
             id: job_id.clone(),
             function_name: function_name.to_string(),
-            job_args: args,
-            job_kwargs: kwargs,
+            job_params: params,
             enqueue_time,
             start_time: None,
             status: JobStatus::Pending,
@@ -172,7 +170,6 @@ mod tests {
     use crate::constants::UNIQUE_JOB_LOCK_PREFIX;
     use crate::test_support::RedisTestContext;
     use chrono::Duration as ChronoDuration;
-    use serde_json::json;
 
     #[tokio::test]
     async fn enqueue_with_defer_by_and_unique_lock() {
@@ -186,7 +183,7 @@ mod tests {
             ..Default::default()
         };
         let job = client
-            .enqueue("task", vec![json!(1)], serde_json::Map::new(), options)
+            .enqueue("task", serde_json::Map::new(), options)
             .await
             .unwrap();
         let scheduled = job.next_scheduled_run_time.unwrap();
@@ -209,7 +206,7 @@ mod tests {
             ..Default::default()
         };
         let job = client
-            .enqueue("task", Vec::new(), serde_json::Map::new(), options)
+            .enqueue("task", serde_json::Map::new(), options)
             .await
             .unwrap();
         let scheduled = job.next_scheduled_run_time.unwrap();
@@ -231,7 +228,7 @@ mod tests {
             ..Default::default()
         };
         let job = client
-            .enqueue("task", Vec::new(), serde_json::Map::new(), options)
+            .enqueue("task", serde_json::Map::new(), options)
             .await
             .unwrap();
         let scheduled = job.next_scheduled_run_time.unwrap();
@@ -259,7 +256,7 @@ mod tests {
             ..Default::default()
         };
         let job = client
-            .enqueue("task", Vec::new(), serde_json::Map::new(), options)
+            .enqueue("task", serde_json::Map::new(), options)
             .await
             .unwrap();
         let scheduled = job.next_scheduled_run_time.unwrap();
@@ -280,7 +277,7 @@ mod tests {
             ..Default::default()
         };
         let err = client
-            .enqueue("task", Vec::new(), serde_json::Map::new(), options)
+            .enqueue("task", serde_json::Map::new(), options)
             .await
             .unwrap_err();
         assert!(
@@ -299,7 +296,7 @@ mod tests {
             ..Default::default()
         };
         let err = client
-            .enqueue("task", Vec::new(), serde_json::Map::new(), options)
+            .enqueue("task", serde_json::Map::new(), options)
             .await
             .unwrap_err();
         assert!(
@@ -325,7 +322,6 @@ mod tests {
         let first = client
             .enqueue(
                 "task",
-                vec![json!(1)],
                 serde_json::Map::new(),
                 options.clone(),
             )
@@ -334,7 +330,7 @@ mod tests {
         assert_eq!(first.id, "fixed-id");
 
         let err = client
-            .enqueue("task", vec![json!(2)], serde_json::Map::new(), options)
+            .enqueue("task", serde_json::Map::new(), options)
             .await
             .unwrap_err();
         assert!(err.to_string().contains("job_id already exists"));
@@ -345,7 +341,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(stored.job_args, vec![json!(1)]);
+        assert!(stored.job_params.is_empty());
         let queue_size = ctx
             .store
             .queue_size(&ctx.settings.default_queue_name)

--- a/rrq-rs/orchestrator/src/client.rs
+++ b/rrq-rs/orchestrator/src/client.rs
@@ -320,11 +320,7 @@ mod tests {
             ..Default::default()
         };
         let first = client
-            .enqueue(
-                "task",
-                serde_json::Map::new(),
-                options.clone(),
-            )
+            .enqueue("task", serde_json::Map::new(), options.clone())
             .await
             .unwrap();
         assert_eq!(first.id, "fixed-id");

--- a/rrq-rs/orchestrator/src/commands/debug.rs
+++ b/rrq-rs/orchestrator/src/commands/debug.rs
@@ -351,8 +351,14 @@ pub(crate) async fn debug_stress_test(
                 .enqueue(
                     "stress_test_job",
                     serde_json::Map::from_iter([
-                        ("job_number".to_string(), Value::from((total_jobs + i) as i64)),
-                        ("batch".to_string(), Value::from(chrono::Utc::now().timestamp())),
+                        (
+                            "job_number".to_string(),
+                            Value::from((total_jobs + i) as i64),
+                        ),
+                        (
+                            "batch".to_string(),
+                            Value::from(chrono::Utc::now().timestamp()),
+                        ),
                     ]),
                     EnqueueOptions {
                         queue_name: Some(queue_name),

--- a/rrq-rs/orchestrator/src/commands/debug.rs
+++ b/rrq-rs/orchestrator/src/commands/debug.rs
@@ -83,11 +83,12 @@ pub(crate) async fn debug_generate_jobs(
         let mut job = Job {
             id: job_id,
             function_name: function_name.to_string(),
-            job_args: vec![
-                Value::String(format!("arg_{i}")),
-                Value::from(rng.random_range(1..=100) as i64),
-            ],
-            job_kwargs: serde_json::Map::from_iter([
+            job_params: serde_json::Map::from_iter([
+                ("arg".to_string(), Value::String(format!("arg_{i}"))),
+                (
+                    "count".to_string(),
+                    Value::from(rng.random_range(1..=100) as i64),
+                ),
                 (
                     "user_id".to_string(),
                     Value::from(rng.random_range(1..=1000) as i64),
@@ -252,7 +253,7 @@ pub(crate) async fn debug_generate_workers(
 pub(crate) async fn debug_submit(
     function_name: String,
     config: Option<String>,
-    args: Option<String>,
+    _args: Option<String>,
     kwargs: Option<String>,
     queue: Option<String>,
     delay: Option<i64>,
@@ -261,20 +262,13 @@ pub(crate) async fn debug_submit(
     let store = JobStore::new(settings.clone()).await?;
     let mut client = RRQClient::new(settings.clone(), store.clone());
 
-    let args_value = args
-        .as_deref()
-        .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
-        .unwrap_or(Value::Array(Vec::new()));
-    let kwargs_value = kwargs
+    // Parse params from kwargs JSON (args is deprecated)
+    let params_value = kwargs
         .as_deref()
         .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
         .unwrap_or(Value::Object(serde_json::Map::new()));
 
-    let args_vec = match args_value {
-        Value::Array(values) => values,
-        _ => Vec::new(),
-    };
-    let kwargs_map = match kwargs_value {
+    let params_map = match params_value {
         Value::Object(map) => map,
         _ => serde_json::Map::new(),
     };
@@ -282,8 +276,7 @@ pub(crate) async fn debug_submit(
     let job = client
         .enqueue(
             &function_name,
-            args_vec,
-            kwargs_map,
+            params_map,
             EnqueueOptions {
                 queue_name: Some(queue.unwrap_or(settings.default_queue_name.clone())),
                 defer_by: delay.map(chrono::Duration::seconds),
@@ -357,11 +350,10 @@ pub(crate) async fn debug_stress_test(
             let _ = client
                 .enqueue(
                     "stress_test_job",
-                    vec![Value::from((total_jobs + i) as i64)],
-                    serde_json::Map::from_iter([(
-                        "batch".to_string(),
-                        Value::from(chrono::Utc::now().timestamp()),
-                    )]),
+                    serde_json::Map::from_iter([
+                        ("job_number".to_string(), Value::from((total_jobs + i) as i64)),
+                        ("batch".to_string(), Value::from(chrono::Utc::now().timestamp())),
+                    ]),
                     EnqueueOptions {
                         queue_name: Some(queue_name),
                         ..Default::default()
@@ -435,8 +427,7 @@ mod tests {
         let job = client
             .enqueue(
                 "cleanup",
-                vec![json!(1)],
-                serde_json::Map::new(),
+                serde_json::Map::from_iter([("n".to_string(), json!(1))]),
                 EnqueueOptions::default(),
             )
             .await?;

--- a/rrq-rs/orchestrator/src/commands/dlq.rs
+++ b/rrq-rs/orchestrator/src/commands/dlq.rs
@@ -340,8 +340,7 @@ mod tests {
         Job {
             id: Job::new_id(),
             function_name: function_name.to_string(),
-            job_args: vec![json!("arg")],
-            job_kwargs: serde_json::Map::new(),
+            job_params: serde_json::Map::from_iter([("arg".to_string(), json!("arg"))]),
             enqueue_time: Utc::now(),
             start_time: None,
             status: JobStatus::Failed,

--- a/rrq-rs/orchestrator/src/commands/queue.rs
+++ b/rrq-rs/orchestrator/src/commands/queue.rs
@@ -260,8 +260,7 @@ mod tests {
         Job {
             id: Job::new_id(),
             function_name: "do_work".to_string(),
-            job_args: vec![],
-            job_kwargs: serde_json::Map::new(),
+            job_params: serde_json::Map::new(),
             enqueue_time: Utc::now(),
             start_time: None,
             status,

--- a/rrq-rs/orchestrator/src/job.rs
+++ b/rrq-rs/orchestrator/src/job.rs
@@ -19,9 +19,7 @@ pub struct Job {
     pub id: String,
     pub function_name: String,
     #[serde(default)]
-    pub job_args: Vec<Value>,
-    #[serde(default)]
-    pub job_kwargs: serde_json::Map<String, Value>,
+    pub job_params: serde_json::Map<String, Value>,
 
     pub enqueue_time: DateTime<Utc>,
     #[serde(default)]

--- a/rrq-rs/orchestrator/src/main.rs
+++ b/rrq-rs/orchestrator/src/main.rs
@@ -620,7 +620,6 @@ while True:
         let job = client
             .enqueue(
                 "demo_job",
-                vec![],
                 serde_json::Map::new(),
                 EnqueueOptions::default(),
             )
@@ -683,7 +682,6 @@ while True:
         let cancel_job = client
             .enqueue(
                 "cancel_me",
-                vec![],
                 serde_json::Map::new(),
                 EnqueueOptions::default(),
             )

--- a/rrq-rs/orchestrator/src/runner.rs
+++ b/rrq-rs/orchestrator/src/runner.rs
@@ -1460,9 +1460,11 @@ mod tests {
 
     #[test]
     fn determine_needed_runners_includes_default() {
-        let mut settings = RRQSettings::default();
-        settings.default_runner_name = "python".to_string();
-        settings.default_queue_name = "default".to_string();
+        let settings = RRQSettings {
+            default_runner_name: "python".to_string(),
+            default_queue_name: "default".to_string(),
+            ..Default::default()
+        };
 
         let needed = super::determine_needed_runners(&settings, None);
         assert!(needed.contains("python"));
@@ -1471,9 +1473,11 @@ mod tests {
 
     #[test]
     fn determine_needed_runners_includes_routed_runners() {
-        let mut settings = RRQSettings::default();
-        settings.default_runner_name = "python".to_string();
-        settings.default_queue_name = "default".to_string();
+        let mut settings = RRQSettings {
+            default_runner_name: "python".to_string(),
+            default_queue_name: "default".to_string(),
+            ..Default::default()
+        };
         settings
             .runner_routes
             .insert("mail-ingest".to_string(), "mail_runner".to_string());
@@ -1490,9 +1494,11 @@ mod tests {
 
     #[test]
     fn determine_needed_runners_uses_default_queue_when_none_provided() {
-        let mut settings = RRQSettings::default();
-        settings.default_runner_name = "python".to_string();
-        settings.default_queue_name = "my-queue".to_string();
+        let mut settings = RRQSettings {
+            default_runner_name: "python".to_string(),
+            default_queue_name: "my-queue".to_string(),
+            ..Default::default()
+        };
         settings
             .runner_routes
             .insert("my-queue".to_string(), "special_runner".to_string());
@@ -1506,9 +1512,11 @@ mod tests {
 
     #[test]
     fn determine_needed_runners_deduplicates() {
-        let mut settings = RRQSettings::default();
-        settings.default_runner_name = "shared".to_string();
-        settings.default_queue_name = "default".to_string();
+        let mut settings = RRQSettings {
+            default_runner_name: "shared".to_string(),
+            default_queue_name: "default".to_string(),
+            ..Default::default()
+        };
         settings
             .runner_routes
             .insert("queue-a".to_string(), "shared".to_string());

--- a/rrq-rs/orchestrator/src/runner.rs
+++ b/rrq-rs/orchestrator/src/runner.rs
@@ -759,8 +759,7 @@ mod tests {
             request_id: "req-1".to_string(),
             job_id: "job-1".to_string(),
             function_name: "echo".to_string(),
-            args: Vec::new(),
-            kwargs: HashMap::new(),
+            params: HashMap::new(),
             context: rrq_protocol::ExecutionContext {
                 job_id: "job-1".to_string(),
                 attempt: 1,
@@ -1209,8 +1208,7 @@ mod tests {
             request_id: "req-1".to_string(),
             job_id: "job-1".to_string(),
             function_name: "echo".to_string(),
-            args: Vec::new(),
-            kwargs: HashMap::new(),
+            params: HashMap::new(),
             context: rrq_protocol::ExecutionContext {
                 job_id: "job-1".to_string(),
                 attempt: 1,
@@ -1266,8 +1264,7 @@ mod tests {
             request_id: "req-1".to_string(),
             job_id: "job-1".to_string(),
             function_name: "echo".to_string(),
-            args: Vec::new(),
-            kwargs: HashMap::new(),
+            params: HashMap::new(),
             context: rrq_protocol::ExecutionContext {
                 job_id: "job-1".to_string(),
                 attempt: 1,

--- a/rrq-rs/orchestrator/src/runner.rs
+++ b/rrq-rs/orchestrator/src/runner.rs
@@ -23,6 +23,8 @@ use tokio::time::{Duration, Instant, timeout};
 
 const ENV_RUNNER_TCP_SOCKET: &str = "RRQ_RUNNER_TCP_SOCKET";
 const MAX_FRAME_LEN: usize = 16 * 1024 * 1024;
+const REUSE_SOCKET_MAX_ATTEMPTS: usize = 5;
+const REUSE_SOCKET_RETRY_DELAY: Duration = Duration::from_millis(50);
 
 fn connect_timeout_from_settings(timeout_ms: i64) -> Duration {
     let ms = if timeout_ms > 0 {
@@ -186,10 +188,10 @@ impl SocketRunnerPool {
         if let Some(spawn_override) = &self.spawn_override {
             return Ok((spawn_override)());
         }
-        let max_attempts = if reuse_socket.is_none() {
-            self.pool_size.max(1)
+        let max_attempts = if reuse_socket.is_some() {
+            REUSE_SOCKET_MAX_ATTEMPTS
         } else {
-            1
+            self.pool_size.max(1)
         };
         let mut attempts = 0;
         loop {
@@ -202,8 +204,11 @@ impl SocketRunnerPool {
             };
             if let Err(err) = self.ensure_tcp_port_available(socket) {
                 attempts += 1;
-                if reuse_socket.is_some() || attempts >= max_attempts {
+                if attempts >= max_attempts {
                     return Err(err);
+                }
+                if reuse_socket.is_some() {
+                    tokio::time::sleep(REUSE_SOCKET_RETRY_DELAY).await;
                 }
                 continue;
             }
@@ -385,7 +390,16 @@ impl SocketRunnerPool {
         // Capture the old socket target to reuse (prevents port exhaustion on TCP)
         let old_socket = guard.socket;
         let _ = self.terminate(&mut guard).await;
-        *guard = self.spawn_process(Some(old_socket)).await?;
+        let replacement = match self.spawn_process(Some(old_socket)).await {
+            Ok(proc) => proc,
+            Err(err) => {
+                tracing::warn!(
+                    "failed to reuse runner socket {old_socket}: {err}; allocating new socket"
+                );
+                self.spawn_process(None).await?
+            }
+        };
+        *guard = replacement;
         self.availability.notify_waiters();
         Ok(())
     }
@@ -616,6 +630,38 @@ struct InFlightRequest {
     socket: RunnerSocketTarget,
 }
 
+/// Determine which runners are needed based on the queues being listened to.
+///
+/// Returns a set of runner names that should be spawned. This includes:
+/// - Runners explicitly mapped to queues via `runner_routes`
+/// - The default runner (for queues without explicit routing)
+pub fn determine_needed_runners(
+    settings: &RRQSettings,
+    queues: Option<&[String]>,
+) -> std::collections::HashSet<String> {
+    let mut needed = std::collections::HashSet::new();
+
+    // Always need the default runner for unrouted queues
+    if !settings.default_runner_name.is_empty() {
+        needed.insert(settings.default_runner_name.clone());
+    }
+
+    // Get the effective queues (CLI override or default)
+    let effective_queues: Vec<String> = match queues {
+        Some(q) if !q.is_empty() => q.to_vec(),
+        _ => vec![settings.default_queue_name.clone()],
+    };
+
+    // Add runners that are explicitly routed to these queues
+    for queue in &effective_queues {
+        if let Some(runner_name) = settings.runner_routes.get(queue) {
+            needed.insert(runner_name.clone());
+        }
+    }
+
+    needed
+}
+
 pub fn resolve_runner_pool_sizes(
     settings: &RRQSettings,
     watch_mode: bool,
@@ -667,6 +713,19 @@ pub async fn build_runners_from_settings(
     pool_sizes: Option<&HashMap<String, usize>>,
     max_in_flight: Option<&HashMap<String, usize>>,
 ) -> Result<HashMap<String, Arc<dyn Runner>>> {
+    build_runners_from_settings_filtered(settings, pool_sizes, max_in_flight, None).await
+}
+
+/// Build runners from settings, optionally filtering to only spawn needed runners.
+///
+/// If `needed_runners` is `Some`, only runners in that set will be spawned.
+/// If `needed_runners` is `None`, all configured runners will be spawned.
+pub async fn build_runners_from_settings_filtered(
+    settings: &RRQSettings,
+    pool_sizes: Option<&HashMap<String, usize>>,
+    max_in_flight: Option<&HashMap<String, usize>>,
+    needed_runners: Option<&std::collections::HashSet<String>>,
+) -> Result<HashMap<String, Arc<dyn Runner>>> {
     let pool_sizes = match pool_sizes {
         Some(map) => map.clone(),
         None => resolve_runner_pool_sizes(settings, false, None)?,
@@ -678,6 +737,14 @@ pub async fn build_runners_from_settings(
     let connect_timeout = connect_timeout_from_settings(settings.runner_connect_timeout_ms);
     let mut runners: HashMap<String, Arc<dyn Runner>> = HashMap::new();
     for (name, config) in &settings.runners {
+        // Skip runners that are not needed (if filter is provided)
+        if let Some(needed) = needed_runners
+            && !needed.contains(name)
+        {
+            tracing::debug!(runner = %name, "skipping runner (not needed for configured queues)");
+            continue;
+        }
+
         // cmd and tcp_socket are validated by the config crate
         let pool_size = pool_sizes
             .get(name)
@@ -1389,5 +1456,71 @@ mod tests {
         assert_ne!(initial_socket, new_socket);
 
         pool.close().await.unwrap();
+    }
+
+    #[test]
+    fn determine_needed_runners_includes_default() {
+        let mut settings = RRQSettings::default();
+        settings.default_runner_name = "python".to_string();
+        settings.default_queue_name = "default".to_string();
+
+        let needed = super::determine_needed_runners(&settings, None);
+        assert!(needed.contains("python"));
+        assert_eq!(needed.len(), 1);
+    }
+
+    #[test]
+    fn determine_needed_runners_includes_routed_runners() {
+        let mut settings = RRQSettings::default();
+        settings.default_runner_name = "python".to_string();
+        settings.default_queue_name = "default".to_string();
+        settings
+            .runner_routes
+            .insert("mail-ingest".to_string(), "mail_runner".to_string());
+        settings
+            .runner_routes
+            .insert("mail-extract".to_string(), "mail_runner".to_string());
+
+        // When listening to mail-ingest queue, should need mail_runner + default
+        let needed = super::determine_needed_runners(&settings, Some(&["mail-ingest".to_string()]));
+        assert!(needed.contains("python")); // default runner
+        assert!(needed.contains("mail_runner")); // routed runner
+        assert_eq!(needed.len(), 2);
+    }
+
+    #[test]
+    fn determine_needed_runners_uses_default_queue_when_none_provided() {
+        let mut settings = RRQSettings::default();
+        settings.default_runner_name = "python".to_string();
+        settings.default_queue_name = "my-queue".to_string();
+        settings
+            .runner_routes
+            .insert("my-queue".to_string(), "special_runner".to_string());
+
+        // When no queues provided, uses default_queue_name which is routed
+        let needed = super::determine_needed_runners(&settings, None);
+        assert!(needed.contains("python")); // default runner
+        assert!(needed.contains("special_runner")); // routed for default queue
+        assert_eq!(needed.len(), 2);
+    }
+
+    #[test]
+    fn determine_needed_runners_deduplicates() {
+        let mut settings = RRQSettings::default();
+        settings.default_runner_name = "shared".to_string();
+        settings.default_queue_name = "default".to_string();
+        settings
+            .runner_routes
+            .insert("queue-a".to_string(), "shared".to_string());
+        settings
+            .runner_routes
+            .insert("queue-b".to_string(), "shared".to_string());
+
+        let needed = super::determine_needed_runners(
+            &settings,
+            Some(&["queue-a".to_string(), "queue-b".to_string()]),
+        );
+        assert!(needed.contains("shared"));
+        assert_eq!(needed.len(), 1); // Only one runner, deduplicated
     }
 }

--- a/rrq-rs/orchestrator/src/store.rs
+++ b/rrq-rs/orchestrator/src/store.rs
@@ -169,15 +169,13 @@ impl JobStore {
     }
 
     fn build_job_mapping(job: &Job) -> Result<Vec<(String, String)>> {
-        let job_args_json = serde_json::to_string(&job.job_args)?;
-        let job_kwargs_json = serde_json::to_string(&job.job_kwargs)?;
+        let job_params_json = serde_json::to_string(&job.job_params)?;
         let result_json = serde_json::to_string(&job.result)?;
 
         let mut mapping: Vec<(String, String)> = vec![
             ("id".to_string(), job.id.clone()),
             ("function_name".to_string(), job.function_name.clone()),
-            ("job_args".to_string(), job_args_json),
-            ("job_kwargs".to_string(), job_kwargs_json),
+            ("job_params".to_string(), job_params_json),
             ("enqueue_time".to_string(), job.enqueue_time.to_rfc3339()),
             ("status".to_string(), job.status.as_str().to_string()),
             (
@@ -309,12 +307,8 @@ impl JobStore {
         fallback_id: &str,
         default_max_retries: i64,
     ) -> Result<Job> {
-        let job_args = raw
-            .get("job_args")
-            .and_then(|value| serde_json::from_str(value).ok())
-            .unwrap_or_default();
-        let job_kwargs = raw
-            .get("job_kwargs")
+        let job_params = raw
+            .get("job_params")
             .and_then(|value| serde_json::from_str(value).ok())
             .unwrap_or_default();
         let result = raw.get("result").and_then(|value| Self::parse_json(value));
@@ -348,8 +342,7 @@ impl JobStore {
                 .cloned()
                 .unwrap_or_else(|| fallback_id.to_string()),
             function_name: raw.get("function_name").cloned().unwrap_or_default(),
-            job_args,
-            job_kwargs,
+            job_params,
             enqueue_time,
             start_time: raw
                 .get("start_time")
@@ -939,8 +932,7 @@ mod tests {
         Job {
             id: Job::new_id(),
             function_name: "do_work".to_string(),
-            job_args: vec![],
-            job_kwargs: serde_json::Map::new(),
+            job_params: serde_json::Map::new(),
             enqueue_time: Utc::now(),
             start_time: None,
             status: JobStatus::Pending,

--- a/rrq-rs/orchestrator/src/worker.rs
+++ b/rrq-rs/orchestrator/src/worker.rs
@@ -1106,11 +1106,7 @@ async fn cron_loop(
                     job_id: None,
                 };
                 if let Err(err) = client
-                    .enqueue(
-                        &due.function_name,
-                        due.params.clone(),
-                        options,
-                    )
+                    .enqueue(&due.function_name, due.params.clone(), options)
                     .await
                 {
                     tracing::error!("cron enqueue failed for {}: {err}", due.function_name);
@@ -1669,11 +1665,7 @@ mod tests {
         runners.insert("test".to_string(), runner);
         let mut client = RRQClient::new(ctx.settings.clone(), ctx.store.clone());
         let job = client
-            .enqueue(
-                "success",
-                serde_json::Map::new(),
-                EnqueueOptions::default(),
-            )
+            .enqueue("success", serde_json::Map::new(), EnqueueOptions::default())
             .await
             .unwrap();
         let mut worker = RRQWorker::new(
@@ -1712,11 +1704,7 @@ mod tests {
         runners.insert("test".to_string(), runner);
         let mut client = RRQClient::new(ctx.settings.clone(), ctx.store.clone());
         let job = client
-            .enqueue(
-                "retry",
-                serde_json::Map::new(),
-                EnqueueOptions::default(),
-            )
+            .enqueue("retry", serde_json::Map::new(), EnqueueOptions::default())
             .await
             .unwrap();
         let mut worker = RRQWorker::new(

--- a/rrq-rs/producer/examples/producer.rs
+++ b/rrq-rs/producer/examples/producer.rs
@@ -16,15 +16,14 @@ async fn main() -> Result<()> {
     let producer = Producer::new(redis_dsn).await?;
 
     for i in 0..count {
-        let args = vec![json!(format!("from-rust-{i}"))];
-        let mut kwargs: Map<String, Value> = Map::new();
-        kwargs.insert("source".to_string(), json!("rust"));
+        let mut params: Map<String, Value> = Map::new();
+        params.insert("message".to_string(), json!(format!("from-rust-{i}")));
+        params.insert("source".to_string(), json!("rust"));
 
         producer
             .enqueue(
                 &function_name,
-                args,
-                kwargs,
+                params,
                 EnqueueOptions {
                     queue_name: Some(queue_name.clone()),
                     ..Default::default()

--- a/rrq-rs/producer/src/lib.rs
+++ b/rrq-rs/producer/src/lib.rs
@@ -744,11 +744,7 @@ mod tests {
 
         let producer = Producer::new(&dsn).await.unwrap();
         let job_id = producer
-            .enqueue(
-                "work",
-                serde_json::Map::new(),
-                EnqueueOptions::default(),
-            )
+            .enqueue("work", serde_json::Map::new(), EnqueueOptions::default())
             .await
             .unwrap();
 
@@ -779,11 +775,7 @@ mod tests {
         };
         let producer = Producer::with_config(&dsn, config).await.unwrap();
         let job_id = producer
-            .enqueue(
-                "work",
-                serde_json::Map::new(),
-                EnqueueOptions::default(),
-            )
+            .enqueue("work", serde_json::Map::new(), EnqueueOptions::default())
             .await
             .unwrap();
 
@@ -1043,11 +1035,7 @@ mod tests {
 
         let producer = Producer::new(&dsn).await.unwrap();
         let job_id = producer
-            .enqueue(
-                "work",
-                serde_json::Map::new(),
-                EnqueueOptions::default(),
-            )
+            .enqueue("work", serde_json::Map::new(), EnqueueOptions::default())
             .await
             .unwrap();
 

--- a/rrq-rs/protocol/README.md
+++ b/rrq-rs/protocol/README.md
@@ -4,15 +4,20 @@
 [![Documentation](https://docs.rs/rrq-protocol/badge.svg)](https://docs.rs/rrq-protocol)
 [![License](https://img.shields.io/crates/l/rrq-protocol.svg)](LICENSE)
 
-Protocol definitions for communication between the [RRQ](https://crates.io/crates/rrq) orchestrator and runner processes.
+**Wire protocol types for RRQ orchestrator-runner communication.**
 
-## Overview
+## What is RRQ?
 
-This crate defines the wire protocol used for socket communication between:
-- **RRQ Orchestrator** - dispatches jobs to runner processes
-- **RRQ Runner** - receives and executes job handlers
+RRQ (Reliable Redis Queue) is a distributed job queue with a Rust orchestrator and language-flexible workers. This crate defines the protocol used for socket communication between the orchestrator and runner processes.
 
-The protocol uses length-prefixed JSON frames over TCP connections.
+## When to Use This Crate
+
+Use `rrq-protocol` if you're:
+- Building a custom runner in a new language
+- Extending the RRQ protocol
+- Debugging orchestrator-runner communication
+
+For most use cases, use [`rrq-runner`](https://crates.io/crates/rrq-runner) which wraps this protocol.
 
 ## Installation
 
@@ -21,7 +26,18 @@ The protocol uses length-prefixed JSON frames over TCP connections.
 rrq-protocol = "0.9"
 ```
 
-## Protocol Messages
+## Protocol Overview
+
+Messages are length-prefixed JSON frames over TCP:
+
+```
+┌─────────────────┬──────────────────────────────┐
+│  Length (4B)    │  JSON Payload (N bytes)      │
+│  Big-endian u32 │  UTF-8 encoded               │
+└─────────────────┴──────────────────────────────┘
+```
+
+## Message Types
 
 ### ExecutionRequest
 
@@ -35,7 +51,7 @@ let request = ExecutionRequest {
     request_id: "req-uuid".to_string(),
     job_id: "job-uuid".to_string(),
     function_name: "send_email".to_string(),
-    params: [("to".to_string(), serde_json::json!("user@example.com"))].into(),
+    params: [("to".to_string(), json!("user@example.com"))].into(),
     context: ExecutionContext {
         job_id: "job-uuid".to_string(),
         attempt: 1,
@@ -50,37 +66,24 @@ let request = ExecutionRequest {
 
 ### ExecutionOutcome
 
-Returned from runner to orchestrator after job execution:
+Returned from runner after job execution:
 
 ```rust
 use rrq_protocol::ExecutionOutcome;
 
 // Success
-let outcome = ExecutionOutcome::success(
-    "job-uuid".to_string(),
-    "req-uuid".to_string(),
-    serde_json::json!({"sent": true}),
-);
+let outcome = ExecutionOutcome::success("job-id", "req-id", json!({"sent": true}));
 
 // Failure
-let outcome = ExecutionOutcome::failure(
-    "job-uuid".to_string(),
-    "req-uuid".to_string(),
-    "Connection timeout".to_string(),
-);
+let outcome = ExecutionOutcome::failure("job-id", "req-id", "Connection timeout");
 
 // Retry after delay
-let outcome = ExecutionOutcome::retry_after(
-    "job-uuid".to_string(),
-    "req-uuid".to_string(),
-    "Rate limited".to_string(),
-    60, // retry after 60 seconds
-);
+let outcome = ExecutionOutcome::retry_after("job-id", "req-id", "Rate limited", 60);
 ```
 
 ### CancelRequest
 
-Sent to runner to cancel an in-flight job:
+Sent to cancel an in-flight job:
 
 ```rust
 use rrq_protocol::CancelRequest;
@@ -95,58 +98,31 @@ let cancel = CancelRequest {
 
 ## Frame Encoding
 
-Messages are encoded as length-prefixed JSON:
-
-```
-┌─────────────────┬──────────────────────────────┐
-│  Length (4B)    │  JSON Payload (N bytes)      │
-│  Big-endian u32 │  UTF-8 encoded               │
-└─────────────────┴──────────────────────────────┘
-```
-
 ```rust
-use rrq_protocol::{encode_frame, RunnerMessage, ExecutionRequest};
+use rrq_protocol::{encode_frame, RunnerMessage};
 
-let message = RunnerMessage::Request {
-    payload: request,
-};
+let message = RunnerMessage::Request { payload: request };
 let frame: Vec<u8> = encode_frame(&message)?;
-// frame = [length_bytes...][json_bytes...]
-```
-
-## Runner Message Envelope
-
-All messages are wrapped in an `RunnerMessage` enum:
-
-```rust
-use rrq_protocol::RunnerMessage;
-
-// Three variants:
-let msg = RunnerMessage::Request { payload: request };
-let msg = RunnerMessage::Response { payload: outcome };
-let msg = RunnerMessage::Cancel { payload: cancel };
 ```
 
 ## Outcome Types
 
-The `outcome_type` field indicates how the job completed:
-
 | Type | Description |
 |------|-------------|
-| `success` | Job completed successfully |
+| `success` | Job completed |
 | `failure` | Job failed (may retry) |
-| `handler_not_found` | No handler registered for function |
-| `timeout` | Job exceeded deadline |
-| `cancelled` | Job was cancelled |
-| `retry_after` | Retry after specified delay |
+| `handler_not_found` | No handler for function |
+| `timeout` | Exceeded deadline |
+| `cancelled` | Job cancelled |
+| `retry_after` | Retry after delay |
 
 ## Related Crates
 
-| Crate | Description |
-|-------|-------------|
-| [`rrq`](https://crates.io/crates/rrq) | Job queue orchestrator |
-| [`rrq-producer`](https://crates.io/crates/rrq-producer) | Client for enqueuing jobs |
-| [`rrq-runner`](https://crates.io/crates/rrq-runner) | Runner runtime implementation |
+| Crate | Purpose |
+|-------|---------|
+| [`rrq`](https://crates.io/crates/rrq) | Orchestrator |
+| [`rrq-runner`](https://crates.io/crates/rrq-runner) | Runner runtime |
+| [`rrq-producer`](https://crates.io/crates/rrq-producer) | Job producer |
 
 ## License
 

--- a/rrq-rs/protocol/README.md
+++ b/rrq-rs/protocol/README.md
@@ -31,12 +31,11 @@ Sent from orchestrator to runner when dispatching a job:
 use rrq_protocol::{ExecutionRequest, ExecutionContext};
 
 let request = ExecutionRequest {
-    protocol_version: "1".to_string(),
+    protocol_version: "2".to_string(),
     request_id: "req-uuid".to_string(),
     job_id: "job-uuid".to_string(),
     function_name: "send_email".to_string(),
-    args: vec![serde_json::json!("user@example.com")],
-    kwargs: std::collections::HashMap::new(),
+    params: [("to".to_string(), serde_json::json!("user@example.com"))].into(),
     context: ExecutionContext {
         job_id: "job-uuid".to_string(),
         attempt: 1,
@@ -87,7 +86,7 @@ Sent to runner to cancel an in-flight job:
 use rrq_protocol::CancelRequest;
 
 let cancel = CancelRequest {
-    protocol_version: "1".to_string(),
+    protocol_version: "2".to_string(),
     job_id: "job-uuid".to_string(),
     request_id: Some("req-uuid".to_string()),
     hard_kill: false,

--- a/rrq-rs/protocol/src/lib.rs
+++ b/rrq-rs/protocol/src/lib.rs
@@ -4,7 +4,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 use std::fmt;
 
-pub const PROTOCOL_VERSION: &str = "1";
+pub const PROTOCOL_VERSION: &str = "2";
 pub const FRAME_HEADER_LEN: usize = 4;
 
 fn default_protocol_version() -> String {
@@ -50,9 +50,7 @@ pub struct ExecutionRequest {
     pub job_id: String,
     pub function_name: String,
     #[serde(default)]
-    pub args: Vec<Value>,
-    #[serde(default)]
-    pub kwargs: HashMap<String, Value>,
+    pub params: HashMap<String, Value>,
     pub context: ExecutionContext,
 }
 
@@ -246,8 +244,7 @@ mod tests {
             "job_id": "job-1",
             "request_id": "req-1",
             "function_name": "echo",
-            "args": [],
-            "kwargs": {},
+            "params": {},
             "context": {
                 "job_id": "job-1",
                 "attempt": 1,
@@ -282,8 +279,7 @@ mod tests {
             request_id: "req-1".to_string(),
             job_id: "job-1".to_string(),
             function_name: "echo".to_string(),
-            args: Vec::new(),
-            kwargs: HashMap::new(),
+            params: HashMap::new(),
             context: ExecutionContext {
                 job_id: "job-1".to_string(),
                 attempt: 1,

--- a/rrq-rs/runner/README.md
+++ b/rrq-rs/runner/README.md
@@ -43,7 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Register a handler
     registry.register("greet", |request| async move {
-        let name = request.args.get(0)
+        let name = request.params.get("name")
             .and_then(|v| v.as_str())
             .unwrap_or("World");
 
@@ -78,13 +78,12 @@ registry.register("process_order", |request: ExecutionRequest| async move {
     println!("Attempt: {}", request.context.attempt);
     println!("Queue: {}", request.context.queue_name);
 
-    // Access arguments
-    let order_id = request.args.get(0)
+    // Access parameters
+    let order_id = request.params.get("order_id")
         .and_then(|v| v.as_str())
         .ok_or("missing order_id")?;
 
-    // Access keyword arguments
-    let priority = request.kwargs.get("priority")
+    let priority = request.params.get("priority")
         .and_then(|v| v.as_str())
         .unwrap_or("normal");
 
@@ -137,7 +136,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         ExecutionOutcome::success(
             req.job_id.clone(),
             req.request_id.clone(),
-            serde_json::json!(req.args),
+            serde_json::json!(req.params),
         )
     });
 

--- a/rrq-rs/runner/examples/socket_runner.rs
+++ b/rrq-rs/runner/examples/socket_runner.rs
@@ -29,8 +29,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             request.request_id.clone(),
             json!({
                 "job_id": request.job_id,
-                "args": request.args,
-                "kwargs": request.kwargs,
+                "params": request.params,
             }),
         )
     });

--- a/rrq-rs/runner/src/runtime.rs
+++ b/rrq-rs/runner/src/runtime.rs
@@ -486,8 +486,7 @@ mod tests {
             request_id: "req-1".to_string(),
             job_id: "job-1".to_string(),
             function_name: function_name.to_string(),
-            args: vec![],
-            kwargs: std::collections::HashMap::new(),
+            params: std::collections::HashMap::new(),
             context: ExecutionContext {
                 job_id: "job-1".to_string(),
                 attempt: 1,
@@ -594,8 +593,7 @@ mod tests {
             request_id: "req-cancel".to_string(),
             job_id: "job-cancel".to_string(),
             function_name: "sleep".to_string(),
-            args: vec![],
-            kwargs: std::collections::HashMap::new(),
+            params: std::collections::HashMap::new(),
             context: ExecutionContext {
                 job_id: "job-cancel".to_string(),
                 attempt: 1,

--- a/rrq-rs/runner/src/telemetry.rs
+++ b/rrq-rs/runner/src/telemetry.rs
@@ -32,12 +32,11 @@ mod tests {
 
     fn build_request() -> ExecutionRequest {
         ExecutionRequest {
-            protocol_version: "1".to_string(),
+            protocol_version: "2".to_string(),
             request_id: "req-1".to_string(),
             job_id: "job-1".to_string(),
             function_name: "handler".to_string(),
-            args: vec![],
-            kwargs: std::collections::HashMap::new(),
+            params: std::collections::HashMap::new(),
             context: ExecutionContext {
                 job_id: "job-1".to_string(),
                 attempt: 1,

--- a/rrq-ts/README.md
+++ b/rrq-ts/README.md
@@ -1,172 +1,248 @@
-# RRQ TypeScript (Producer + Runner)
+# RRQ TypeScript
 
-TypeScript/JavaScript package for RRQ (Reliable Redis Queue). Includes:
+[![npm](https://img.shields.io/npm/v/rrq-ts.svg)](https://www.npmjs.com/package/rrq-ts)
+[![License](https://img.shields.io/npm/l/rrq-ts.svg)](LICENSE)
 
-- **Producer** client for enqueuing jobs into RRQ.
-- **Runner runtime** to run job handlers over the RRQ socket protocol.
+**TypeScript/JavaScript client for RRQ**, the distributed job queue with a Rust-powered orchestrator.
 
-Designed to work with **Node.js (20+)** and **Bun**. The producer FFI uses
-`koffi` on Node and `bun:ffi` when running under Bun.
+## What is RRQ?
 
-## Installation
+RRQ (Reliable Redis Queue) is a distributed job queue that separates the hard parts (scheduling, retries, locking, timeouts) into a Rust orchestrator while letting you write job handlers in your preferred language. It uses Redis as the source of truth with atomic operations for reliability.
+
+**Why RRQ?**
+
+- **Language flexibility** - Write job handlers in TypeScript, Python, or Rust
+- **Rust orchestrator** - The complex distributed systems logic is handled by battle-tested Rust code
+- **Production features built in** - Retries, dead letter queues, timeouts, cron scheduling, distributed tracing
+- **Redis simplicity** - No separate databases; everything lives in Redis with predictable semantics
+
+## This Package
+
+This package provides:
+
+- **Producer client** - Enqueue jobs from Node.js/Bun applications
+- **Runner runtime** - Execute job handlers written in TypeScript
+
+Works with **Node.js 20+** and **Bun**.
+
+## Quick Start
+
+### 1. Install
 
 ```bash
 npm install rrq-ts
+# or
+bun add rrq-ts
 ```
 
-## Producer usage
+### 2. Enqueue jobs (Producer)
 
-```ts
+```typescript
 import { RRQClient } from "rrq-ts";
 
 const client = new RRQClient({
-  config: {
-    redisDsn: "redis://localhost:6379/0",
-  },
+  config: { redisDsn: "redis://localhost:6379/0" }
 });
 
 const jobId = await client.enqueue("send_email", {
-  args: ["user@example.com"],
-  kwargs: { template: "welcome" },
-  queueName: "rrq:queue:default",
-  maxRetries: 5,
+  params: { to: "user@example.com", template: "welcome" },
+  queueName: "emails",
+  maxRetries: 5
 });
 
-console.log("enqueued", jobId);
+console.log(`Enqueued job: ${jobId}`);
 await client.close();
 ```
 
-### Producer requirements
+### 3. Write job handlers (Runner)
 
-The TypeScript producer uses the Rust `rrq_producer` shared library via FFI.
-Provide the library in one of these ways:
-
-- Set `RRQ_PRODUCER_LIB_PATH` to the absolute path of the shared library.
-- Place the library in `rrq-ts/bin` (e.g. `librrq_producer.dylib` or `librrq_producer.so`).
-- For published packages, place the library in `rrq-ts/bin/<platform>-<arch>/`
-  (for example, `bin/linux-x64/librrq_producer.so` or
-  `bin/darwin-arm64/librrq_producer.dylib`).
-
-To build the library from this repo:
-
-```bash
-cargo build -p rrq-producer --release
-```
-
-### Producer config from rrq.toml
-
-```ts
-const client = new RRQClient({ configPath: "rrq.toml" });
-```
-
-### Producer options
-
-```ts
-interface EnqueueOptions {
-  args?: unknown[];
-  kwargs?: Record<string, unknown>;
-  queueName?: string;
-  jobId?: string;
-  uniqueKey?: string;
-  uniqueTtlSeconds?: number;
-  maxRetries?: number;
-  jobTimeoutSeconds?: number;
-  resultTtlSeconds?: number;
-  deferUntil?: Date;
-  deferBySeconds?: number;
-  traceContext?: Record<string, string> | null;
-}
-```
-
-`uniqueKey` is idempotency: repeated enqueues with the same key return the same
-job id.
-
-### Rate limit / debounce
-
-```ts
-const jobId = await client.enqueueWithRateLimit("send_email", {
-  rateLimitKey: "user-123",
-  rateLimitSeconds: 5,
-});
-if (jobId === null) {
-  // rate limited
-}
-
-const debouncedId = await client.enqueueWithDebounce("sync_user", {
-  debounceKey: "user-123",
-  debounceSeconds: 5,
-});
-```
-
-### Job status + results
-
-```ts
-const status = await client.getJobStatus(jobId);
-```
-
-## Runner runtime usage
-
-```ts
-import { RunnerRuntime, Registry } from "rrq-ts";
+```typescript
+import { RunnerRuntime, Registry, ExecutionOutcome } from "rrq-ts";
 
 const registry = new Registry();
+
 registry.register("send_email", async (request, signal) => {
-  // handle request.args / request.kwargs; use signal for cancellation
-  return {
-    job_id: request.job_id,
-    request_id: request.request_id,
-    status: "success",
-    result: { ok: true },
-  };
+  const { to, template } = request.params;
+
+  // Your email sending logic here
+  await sendEmail(to, template);
+
+  return ExecutionOutcome.success(
+    request.job_id,
+    request.request_id,
+    { sent: true, to }
+  );
 });
 
 const runtime = new RunnerRuntime(registry);
 await runtime.runFromEnv();
 ```
 
-The orchestrator sets `RRQ_RUNNER_TCP_SOCKET` when launching runners. You
-can also run the runtime directly:
+### 4. Configure (`rrq.toml`)
 
-```bash
-RRQ_RUNNER_TCP_SOCKET=127.0.0.1:9000 node dist/runner_runtime.js
+```toml
+[rrq]
+redis_dsn = "redis://localhost:6379/0"
+default_runner_name = "node"
+
+[rrq.runners.node]
+type = "socket"
+cmd = ["node", "dist/runner.js"]
+tcp_socket = "127.0.0.1:9000"
+pool_size = 4
+max_in_flight = 10
 ```
 
-### OpenTelemetry (runner)
+### 5. Run
 
-```ts
-import { RunnerRuntime, Registry } from "rrq-ts";
-import { OtelTelemetry } from "rrq-ts";
+```bash
+# Install the RRQ orchestrator
+cargo install rrq
+# or download from releases
 
-const registry = new Registry();
+# Start the orchestrator (spawns runners automatically)
+rrq worker run --config rrq.toml
+```
+
+## Producer API
+
+### Enqueue Options
+
+```typescript
+interface EnqueueOptions {
+  params?: Record<string, unknown>;  // Job parameters
+  queueName?: string;                 // Target queue (default: "default")
+  jobId?: string;                     // Custom job ID
+  maxRetries?: number;                // Max retry attempts
+  jobTimeoutSeconds?: number;         // Execution timeout
+  resultTtlSeconds?: number;          // How long to keep results
+  deferUntil?: Date;                  // Schedule for specific time
+  deferBySeconds?: number;            // Delay execution
+  traceContext?: Record<string, string>;  // Distributed tracing
+}
+```
+
+### Unique Jobs (Idempotency)
+
+```typescript
+const jobId = await client.enqueueWithUniqueKey(
+  "process_order",
+  "order-123",  // unique key
+  { params: { orderId: "123" } }
+);
+```
+
+### Rate Limiting
+
+```typescript
+const jobId = await client.enqueueWithRateLimit("sync_user", {
+  params: { userId: "456" },
+  rateLimitKey: "user-456",
+  rateLimitSeconds: 60
+});
+
+if (jobId === null) {
+  console.log("Rate limited");
+}
+```
+
+### Debouncing
+
+```typescript
+await client.enqueueWithDebounce("save_document", {
+  params: { docId: "789" },
+  debounceKey: "doc-789",
+  debounceSeconds: 5
+});
+```
+
+### Job Status
+
+```typescript
+const status = await client.getJobStatus(jobId);
+console.log(status);
+```
+
+## Runner API
+
+### Handler Signature
+
+```typescript
+type Handler = (
+  request: ExecutionRequest,
+  signal: AbortSignal
+) => Promise<ExecutionOutcome>;
+```
+
+### Execution Request
+
+```typescript
+interface ExecutionRequest {
+  job_id: string;
+  request_id: string;
+  function_name: string;
+  params: Record<string, unknown>;
+  context: {
+    attempt: number;
+    queue_name: string;
+    enqueue_time: string;
+    deadline?: string;
+  };
+}
+```
+
+### Outcome Types
+
+```typescript
+// Success
+ExecutionOutcome.success(jobId, requestId, { result: "data" });
+
+// Failure (may be retried)
+ExecutionOutcome.failure(jobId, requestId, "Something went wrong");
+
+// Explicit retry after delay
+ExecutionOutcome.retryAfter(jobId, requestId, "Rate limited", 60);
+```
+
+### OpenTelemetry
+
+```typescript
+import { RunnerRuntime, Registry, OtelTelemetry } from "rrq-ts";
+
 const runtime = new RunnerRuntime(registry, new OtelTelemetry());
 await runtime.runFromEnv();
 ```
 
-See `docs/TELEMETRY.md` for end-to-end producer → runner tracing.
+## Producer FFI Setup
 
-## Build
+The producer uses a Rust FFI library for consistent behavior across languages. The library is loaded from:
 
-```bash
-bun run build
-```
+1. `RRQ_PRODUCER_LIB_PATH` environment variable
+2. `rrq-ts/bin/<platform>-<arch>/` (for published packages)
+3. `rrq-ts/bin/` (for development)
 
-## Tests
-
-```bash
-bun test
-```
-
-If you need the Rust FFI library built automatically:
+Build from source:
 
 ```bash
-sh ../scripts/with-producer-lib.sh -- sh -c "cd rrq-ts && bun test"
+cargo build -p rrq-producer --release
+# Copy to bin/darwin-arm64/ or bin/linux-x64/ as appropriate
 ```
 
-## Notes
+## Related Packages
 
-- Producer uses the Rust FFI library for enqueue semantics consistent with RRQ's
-  Rust/Python producers.
-- The runner implements the RRQ v1 socket protocol.
+| Package | Language | Purpose |
+|---------|----------|---------|
+| [rrq-ts](https://www.npmjs.com/package/rrq-ts) | TypeScript | Producer + runner (this package) |
+| [rrq](https://pypi.org/project/rrq/) | Python | Producer + runner |
+| [rrq](https://crates.io/crates/rrq) | Rust | Orchestrator binary |
+| [rrq-producer](https://crates.io/crates/rrq-producer) | Rust | Native producer |
+| [rrq-runner](https://crates.io/crates/rrq-runner) | Rust | Native runner |
+
+## Requirements
+
+- Node.js 20+ or Bun
+- Redis 5.0+
+- RRQ orchestrator binary
 
 ## License
 

--- a/rrq-ts/examples/integration_producer.ts
+++ b/rrq-ts/examples/integration_producer.ts
@@ -23,8 +23,7 @@ const client = new RRQClient({
 try {
   for (let i = 0; i < count; i += 1) {
     await client.enqueue(functionName, {
-      args: [`from-ts-${i}`],
-      kwargs: { source: "ts" },
+      params: { message: `from-ts-${i}`, source: "ts" },
     });
   }
 } finally {

--- a/rrq-ts/src/producer.ts
+++ b/rrq-ts/src/producer.ts
@@ -12,8 +12,7 @@ export interface ProducerConfig {
 }
 
 export interface EnqueueOptions {
-  args?: unknown[];
-  kwargs?: Record<string, unknown>;
+  params?: Record<string, unknown>;
   queueName?: string;
   jobId?: string;
   uniqueKey?: string;
@@ -64,8 +63,7 @@ const ProducerRequestSchema = z
   .object({
     mode: z.string().optional(),
     function_name: z.string().min(1),
-    args: z.array(z.any()),
-    kwargs: z.record(z.any()),
+    params: z.record(z.any()),
     options: ProducerOptionsSchema,
   })
   .strict();
@@ -149,8 +147,7 @@ export class RRQClient {
   ): Promise<ProducerResponse> {
     const request: Record<string, unknown> = {
       function_name: functionName,
-      args: options.args ?? [],
-      kwargs: options.kwargs ?? {},
+      params: options.params ?? {},
       options: this.buildOptions(options),
     };
     if (mode) {

--- a/rrq-ts/src/runner_runtime.ts
+++ b/rrq-ts/src/runner_runtime.ts
@@ -2,7 +2,7 @@ import net from "node:net";
 import { fileURLToPath } from "node:url";
 
 export const ENV_RUNNER_TCP_SOCKET = "RRQ_RUNNER_TCP_SOCKET";
-export const PROTOCOL_VERSION = "1";
+export const PROTOCOL_VERSION = "2";
 const MAX_FRAME_LEN = 16 * 1024 * 1024;
 const MAX_IN_FLIGHT_PER_CONNECTION = 64;
 
@@ -57,8 +57,7 @@ export interface ExecutionRequest {
   request_id: string;
   job_id: string;
   function_name: string;
-  args: unknown[];
-  kwargs: Record<string, unknown>;
+  params: Record<string, unknown>;
   context: ExecutionContext;
 }
 

--- a/rrq-ts/src/runner_runtime.ts
+++ b/rrq-ts/src/runner_runtime.ts
@@ -110,7 +110,17 @@ export class Registry {
     try {
       const result = await handler(request, signal);
       if (isExecutionOutcome(result)) {
-        return result;
+        const jobId =
+          result.job_id && result.job_id.length > 0 ? result.job_id : request.job_id;
+        const requestId =
+          result.request_id && result.request_id.length > 0
+            ? result.request_id
+            : request.request_id;
+        return {
+          ...result,
+          job_id: jobId,
+          request_id: requestId,
+        };
       }
       return {
         job_id: request.job_id,

--- a/rrq-ts/src/runner_runtime.ts
+++ b/rrq-ts/src/runner_runtime.ts
@@ -110,8 +110,7 @@ export class Registry {
     try {
       const result = await handler(request, signal);
       if (isExecutionOutcome(result)) {
-        const jobId =
-          result.job_id && result.job_id.length > 0 ? result.job_id : request.job_id;
+        const jobId = result.job_id && result.job_id.length > 0 ? result.job_id : request.job_id;
         const requestId =
           result.request_id && result.request_id.length > 0
             ? result.request_id

--- a/rrq-ts/tests/producer.integration.test.ts
+++ b/rrq-ts/tests/producer.integration.test.ts
@@ -37,8 +37,7 @@ describe("RRQClient producer integration", () => {
 
   it("enqueues job and stores it in Redis", async () => {
     const jobId = await client.enqueue("handler", {
-      args: [1],
-      kwargs: { ok: true },
+      params: { n: 1, ok: true },
     });
 
     const jobKey = `${CONSTANTS.job_key_prefix}${jobId}`;

--- a/rrq-ts/tests/runner_runtime.integration.test.ts
+++ b/rrq-ts/tests/runner_runtime.integration.test.ts
@@ -14,8 +14,7 @@ type ExecutionRequestPayload = {
   request_id: string;
   job_id: string;
   function_name: string;
-  args: unknown[];
-  kwargs: Record<string, unknown>;
+  params: Record<string, unknown>;
   context: {
     job_id: string;
     attempt: number;
@@ -100,12 +99,11 @@ async function withServer(
 
 function buildRequest(overrides?: Partial<ExecutionRequestPayload>): ExecutionRequestPayload {
   return {
-    protocol_version: "1",
+    protocol_version: "2",
     request_id: "req-1",
     job_id: "job-1",
     function_name: "handler",
-    args: [],
-    kwargs: {},
+    params: {},
     context: {
       job_id: "job-1",
       attempt: 1,
@@ -204,7 +202,7 @@ describe("RunnerRuntime integration", () => {
         encodeMessage({
           type: "cancel",
           payload: {
-            protocol_version: "1",
+            protocol_version: "2",
             job_id: jobId,
             request_id: null,
             hard_kill: false,
@@ -272,7 +270,7 @@ describe("RunnerRuntime integration", () => {
         encodeMessage({
           type: "cancel",
           payload: {
-            protocol_version: "1",
+            protocol_version: "2",
             job_id: jobId,
             request_id: null,
             hard_kill: false,

--- a/rrq-ts/tests/runner_runtime.test.ts
+++ b/rrq-ts/tests/runner_runtime.test.ts
@@ -3,12 +3,11 @@ import { describe, expect, it } from "bun:test";
 import { Registry, parseTcpSocket } from "../src/runner_runtime.js";
 
 const baseRequest = {
-  protocol_version: "1",
+  protocol_version: "2",
   request_id: "req-1",
   job_id: "job-1",
   function_name: "handler",
-  args: [],
-  kwargs: {},
+  params: {},
   context: {
     job_id: "job-1",
     attempt: 1,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> Changes the wire protocol version and Redis job schema from `args`/`kwargs` to `params`, requiring coordinated upgrades across orchestrator and all runners/producers to avoid incompatibility or mis-serialized jobs.
> 
> **Overview**
> **Upgrades RRQ to protocol v2 and a unified job payload.** The orchestrator, Rust producer/FFI, Python client/runner runtime, and docs/examples switch from `args`/`kwargs` to a single `params` object; Redis job storage fields move to `job_params`, and protocol version defaults/checks bump to `"2"`.
> 
> Improves orchestrator runtime behavior by **spawning only runners needed for the selected queues** (via `runner_routes` + default runner) and by making runner respawns more robust (retrying socket reuse and falling back to a new port when reuse fails). Config validation now uses CPU-count as the default `pool_size` when checking port ranges, and the CLI debug/job replay paths are updated to the new params model (with `--args` marked deprecated).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd15c12aee10cc61fa5e9327acd1f0a96f8be419. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->