### PR TITLE
Normalize queue names in Rust across config, orchestrator, worker routing, and CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,17 +1,27 @@
 # RRQ
 
-Redis-based async job queue library for Python.
+Rust-first distributed Redis job queue, with Python and TypeScript bindings.
 
-See @rrq-py/tests/CLAUDE.md for testing guidelines.
+See @rrq-py/tests/CLAUDE.md for Python-specific testing guidelines.
 
 ## Commands
 ```bash
+# Rust core (primary)
+cd rrq-rs
+cargo fmt && cargo clippy
+cargo test
+
+# TypeScript bindings
+sh scripts/with-producer-lib.sh -- sh -c "cd rrq-ts && bun test"
+cd rrq-ts && bun run lint
+
+# Python bindings
 cd rrq-py
-uv run pytest                     # Run tests
-uv run pytest --maxfail=1         # Debug failing tests
-uv run ruff format && uv run ruff check --fix   # Format and lint (run before commits)
-uv run ty check                   # Type check (must pass before commits)
-uv add <package>                  # Add dependency
+uv run pytest
+uv run pytest --maxfail=1
+uv run ruff format && uv run ruff check --fix
+uv run ty check
+uv add <package>
 ```
 
 ## Repo-Wide Testing
@@ -44,19 +54,24 @@ Notes:
 - The `with-producer-lib.sh` wrapper builds and exports the producer FFI lib.
 
 ## Code Style
-- Python 3.11+, double quotes, 88 char lines
-- Type hints on all functions, Pydantic V2 for validation
-- `snake_case` functions, `PascalCase` classes
-- Import order: stdlib → third-party → local
-- Early returns, `match/case` for complex conditionals
-- No blocking I/O in async contexts
+- Rust (`rrq-rs`): idiomatic Rust patterns, run `cargo fmt` and `clippy`.
+- TypeScript (`rrq-ts`): keep strict typing and run `bun run lint`.
+- Python (`rrq-py`): Python 3.11+, double quotes, 88 char lines.
+- Python: type hints on all functions, Pydantic V2 for validation.
+- Python: `snake_case` functions, `PascalCase` classes.
+- Python: import order stdlib → third-party → local.
+- Python: early returns, `match/case` for complex conditionals.
+- Python: no blocking I/O in async contexts.
 
 ## Code References
-Use VS Code clickable format: `rrq-py/rrq/queue.py:45` or `rrq-py/rrq/worker.py:120-135`
+Use VS Code clickable format:
+- `rrq-rs/orchestrator/src/worker.rs:120`
+- `rrq-py/rrq/queue.py:45`
+- `rrq-ts/src/producer.ts:88`
 
 ## Rules
 - Never commit broken tests
-- Use `uv` for all Python operations
+- Use `uv` for Python operations in `rrq-py`
 - Follow existing patterns in codebase
 - No sensitive data in logs
 - Ask before large cross-domain changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,17 +1,27 @@
 # RRQ
 
-Redis-based async job queue library for Python.
+Rust-first distributed Redis job queue, with Python and TypeScript bindings.
 
-See @rrq-py/tests/CLAUDE.md for testing guidelines.
+See @rrq-py/tests/CLAUDE.md for Python-specific testing guidelines.
 
 ## Commands
 ```bash
+# Rust core (primary)
+cd rrq-rs
+cargo fmt && cargo clippy
+cargo test
+
+# TypeScript bindings
+sh scripts/with-producer-lib.sh -- sh -c "cd rrq-ts && bun test"
+cd rrq-ts && bun run lint
+
+# Python bindings
 cd rrq-py
-uv run pytest                     # Run tests
-uv run pytest --maxfail=1         # Debug failing tests
-uv run ruff format && uv run ruff check --fix   # Format and lint (run before commits)
-uv run ty check                   # Type check (must pass before commits)
-uv add <package>                  # Add dependency
+uv run pytest
+uv run pytest --maxfail=1
+uv run ruff format && uv run ruff check --fix
+uv run ty check
+uv add <package>
 ```
 
 ## Repo-Wide Testing
@@ -44,19 +54,24 @@ Notes:
 - The `with-producer-lib.sh` wrapper builds and exports the producer FFI lib.
 
 ## Code Style
-- Python 3.11+, double quotes, 88 char lines
-- Type hints on all functions, Pydantic V2 for validation
-- `snake_case` functions, `PascalCase` classes
-- Import order: stdlib → third-party → local
-- Early returns, `match/case` for complex conditionals
-- No blocking I/O in async contexts
+- Rust (`rrq-rs`): idiomatic Rust patterns, run `cargo fmt` and `clippy`.
+- TypeScript (`rrq-ts`): keep strict typing and run `bun run lint`.
+- Python (`rrq-py`): Python 3.11+, double quotes, 88 char lines.
+- Python: type hints on all functions, Pydantic V2 for validation.
+- Python: `snake_case` functions, `PascalCase` classes.
+- Python: import order stdlib → third-party → local.
+- Python: early returns, `match/case` for complex conditionals.
+- Python: no blocking I/O in async contexts.
 
 ## Code References
-Use VS Code clickable format: `rrq-py/rrq/queue.py:45` or `rrq-py/rrq/worker.py:120-135`
+Use VS Code clickable format:
+- `rrq-rs/orchestrator/src/worker.rs:120`
+- `rrq-py/rrq/queue.py:45`
+- `rrq-ts/src/producer.ts:88`
 
 ## Rules
 - Never commit broken tests
-- Use `uv` for all Python operations
+- Use `uv` for Python operations in `rrq-py`
 - Follow existing patterns in codebase
 - No sensitive data in logs
 - Ask before large cross-domain changes

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
-**A distributed job queue that actually works.** RRQ combines a battle-tested Rust orchestrator with language-flexible workers, giving you the reliability of proven infrastructure with the flexibility of writing job handlers in Python, TypeScript, or Rust.
+**A distributed job queue that actually works.** RRQ is Rust-first: the orchestrator, protocol, and core producer/runner crates are implemented in Rust, with Python and TypeScript bindings for application integration.
 
 ## Why RRQ?
 
@@ -56,13 +56,29 @@ Most job queues make you choose: either fight with complex distributed systems c
 
 | Package | Language | Purpose | Install |
 |---------|----------|---------|---------|
-| [rrq](https://pypi.org/project/rrq/) | Python | Producer + runner | `pip install rrq` |
-| [rrq-ts](https://www.npmjs.com/package/rrq-ts) | TypeScript | Producer + runner | `npm install rrq-ts` |
-| [rrq](https://crates.io/crates/rrq) | Rust | Orchestrator CLI | `cargo install rrq` |
-| [rrq-producer](https://crates.io/crates/rrq-producer) | Rust | Native producer | `rrq-producer = "0.9"` |
-| [rrq-runner](https://crates.io/crates/rrq-runner) | Rust | Native runner | `rrq-runner = "0.9"` |
+| [rrq (crates.io)](https://crates.io/crates/rrq) | Rust | Orchestrator CLI (core) | `cargo install rrq` |
+| [rrq-producer](https://crates.io/crates/rrq-producer) | Rust | Native producer library | `rrq-producer = "0.9"` |
+| [rrq-runner](https://crates.io/crates/rrq-runner) | Rust | Native runner runtime | `rrq-runner = "0.9"` |
+| [rrq (PyPI)](https://pypi.org/project/rrq/) | Python | Producer + runner binding | `pip install rrq` |
+| [rrq-ts](https://www.npmjs.com/package/rrq-ts) | TypeScript | Producer + runner binding | `npm install rrq-ts` |
 
-## Quick Start (Python)
+## Quick Start (Rust Core)
+
+### 1. Install the orchestrator CLI
+
+```bash
+cargo install rrq
+```
+
+### 2. Verify installation
+
+```bash
+rrq --help
+```
+
+## Quick Start (Python Binding)
+
+This binding runs on top of the Rust `rrq` orchestrator.
 
 ### 1. Install
 
@@ -121,7 +137,9 @@ client = RRQClient(config_path="rrq.toml")
 job_id = await client.enqueue("send_email", {"params": {"email": "user@example.com"}})
 ```
 
-## Quick Start (TypeScript)
+## Quick Start (TypeScript Binding)
+
+This binding runs on top of the Rust `rrq` orchestrator.
 
 ```typescript
 import { RRQClient, RunnerRuntime, Registry } from "rrq-ts";
@@ -160,14 +178,15 @@ await runtime.runFromArgs();
 rrq/
 ├── docs/           # Documentation
 ├── examples/       # Usage examples
-├── rrq-py/         # Python package
 ├── rrq-rs/         # Rust workspace (orchestrator, producer, runner, protocol)
+├── rrq-py/         # Python binding package
 └── rrq-ts/         # TypeScript package
 ```
 
 ## Requirements
 
 - Redis 5.0+
+- Rust toolchain (for RRQ core/orchestrator)
 - Python 3.11+ (for Python SDK)
 - Node.js 20+ or Bun (for TypeScript SDK)
 

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -12,11 +12,12 @@ All durations are in seconds unless noted otherwise.
 ```toml
 [rrq]
 redis_dsn = "redis://localhost:6379/1"
-default_runner_name = "python"
+default_runner_name = "worker"
 
-[rrq.runners.python]
+[rrq.runners.worker]
 type = "socket"
-cmd = ["rrq-runner", "--settings", "myapp.runner_config.python_runner_settings"]
+cmd = ["your-runner-binary", "--tcp-socket", "127.0.0.1:9000"]
+tcp_socket = "127.0.0.1:9000"
 ```
 
 ## [rrq]

--- a/rrq-py/pyproject.toml
+++ b/rrq-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rrq"
-version = "0.9.16"
+version = "0.9.17"
 authors = [{ name = "Mazdak Rezvani", email = "mazdak@me.com" }]
 description = "RRQ is a library for creating reliable job queues using Rust, Redis. with language-agnostic producers and workers."
 readme = "README.md"

--- a/rrq-py/uv.lock
+++ b/rrq-py/uv.lock
@@ -573,7 +573,7 @@ hiredis = [
 
 [[package]]
 name = "rrq"
-version = "0.9.16"
+version = "0.9.17"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/rrq-rs/Cargo.lock
+++ b/rrq-rs/Cargo.lock
@@ -1518,7 +1518,7 @@ dependencies = [
 
 [[package]]
 name = "rrq"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "rrq-config"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1566,7 +1566,7 @@ dependencies = [
 
 [[package]]
 name = "rrq-producer"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1582,7 +1582,7 @@ dependencies = [
 
 [[package]]
 name = "rrq-protocol"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "chrono",
  "serde",
@@ -1591,7 +1591,7 @@ dependencies = [
 
 [[package]]
 name = "rrq-runner"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "async-trait",
  "chrono",

--- a/rrq-rs/config/Cargo.toml
+++ b/rrq-rs/config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrq-config"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2024"
 license = "Apache-2.0"
 description = "RRQ configuration loader and settings types."

--- a/rrq-rs/config/src/defaults.rs
+++ b/rrq-rs/config/src/defaults.rs
@@ -1,4 +1,5 @@
 pub const DEFAULT_REDIS_DSN: &str = "redis://localhost:6379/0";
+pub const QUEUE_KEY_PREFIX: &str = "rrq:queue:";
 pub const DEFAULT_QUEUE_NAME: &str = "rrq:queue:default";
 pub const DEFAULT_DLQ_NAME: &str = "rrq:dlq:default";
 

--- a/rrq-rs/config/src/lib.rs
+++ b/rrq-rs/config/src/lib.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod cron;
 pub mod defaults;
 pub mod producer;
+pub mod queue;
 pub mod settings;
 pub mod tcp_socket;
 
@@ -11,5 +12,6 @@ pub use config::{
 pub use cron::CronJob;
 pub use defaults::*;
 pub use producer::{ProducerSettings, load_producer_settings};
+pub use queue::normalize_queue_name;
 pub use settings::{RRQSettings, RunnerConfig, RunnerType, WatchSettings};
 pub use tcp_socket::{TcpSocketSpec, parse_tcp_socket};

--- a/rrq-rs/config/src/queue.rs
+++ b/rrq-rs/config/src/queue.rs
@@ -1,0 +1,27 @@
+use crate::defaults::QUEUE_KEY_PREFIX;
+
+pub fn normalize_queue_name(queue_name: &str) -> String {
+    if queue_name.starts_with(QUEUE_KEY_PREFIX) {
+        queue_name.to_string()
+    } else {
+        format!("{QUEUE_KEY_PREFIX}{queue_name}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_queue_name;
+
+    #[test]
+    fn normalize_queue_name_adds_prefix_for_bare_names() {
+        assert_eq!(normalize_queue_name("default"), "rrq:queue:default");
+    }
+
+    #[test]
+    fn normalize_queue_name_preserves_prefixed_names() {
+        assert_eq!(
+            normalize_queue_name("rrq:queue:mail-ingest"),
+            "rrq:queue:mail-ingest"
+        );
+    }
+}

--- a/rrq-rs/orchestrator/Cargo.toml
+++ b/rrq-rs/orchestrator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrq"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2024"
 license = "Apache-2.0"
 description = "RRQ orchestrator CLI and worker runtime."
@@ -40,13 +40,13 @@ opentelemetry-otlp = { version = "0.31.0", default-features = false, features = 
 opentelemetry_sdk = { version = "0.31.0", default-features = false, features = ["trace", "rt-tokio", "experimental_trace_batch_span_processor_with_async_runtime"] }
 tracing-opentelemetry = "0.32.1"
 
-rrq-protocol = { version = "0.9.16", path = "../protocol" }
-rrq-config = { version = "0.9.16", path = "../config" }
+rrq-protocol = { version = "0.9.17", path = "../protocol" }
+rrq-config = { version = "0.9.17", path = "../config" }
 
 [dev-dependencies]
 serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["io-std", "io-util", "macros", "rt-multi-thread"] }
-rrq-producer = { version = "0.9.16", path = "../producer" }
+rrq-producer = { version = "0.9.17", path = "../producer" }
 
 [lints]
 workspace = true

--- a/rrq-rs/orchestrator/src/commands/debug.rs
+++ b/rrq-rs/orchestrator/src/commands/debug.rs
@@ -10,6 +10,7 @@ use tokio::time::Duration;
 use rrq::load_toml_settings;
 use rrq::store::JobStore;
 use rrq::{EnqueueOptions, Job, JobStatus, RRQClient};
+use rrq_config::normalize_queue_name;
 
 fn worker_tick_sleep() -> Duration {
     if cfg!(test) {
@@ -40,6 +41,10 @@ pub(crate) async fn debug_generate_jobs(
     } else {
         queue_names
     };
+    let queue_names: Vec<String> = queue_names
+        .into_iter()
+        .map(|queue_name| normalize_queue_name(&queue_name))
+        .collect();
     let statuses = if statuses.is_empty() {
         vec![
             "pending".to_string(),
@@ -232,8 +237,8 @@ pub(crate) async fn debug_generate_workers(
             data.insert(
                 "queues".to_string(),
                 Value::Array(vec![
-                    Value::String("test".to_string()),
-                    Value::String("default".to_string()),
+                    Value::String(normalize_queue_name("test")),
+                    Value::String(normalize_queue_name("default")),
                 ]),
             );
             data.insert(
@@ -352,6 +357,10 @@ pub(crate) async fn debug_stress_test(
     } else {
         queues
     };
+    let queues: Vec<String> = queues
+        .into_iter()
+        .map(|queue_name| normalize_queue_name(&queue_name))
+        .collect();
     println!("Starting stress test: {jobs_per_second} jobs/sec for {duration}s");
     let start = Instant::now();
     let mut total_jobs = 0u64;

--- a/rrq-rs/orchestrator/src/commands/job.rs
+++ b/rrq-rs/orchestrator/src/commands/job.rs
@@ -390,6 +390,14 @@ mod tests {
         job_replay(job.id.clone(), config_path.clone(), None).await?;
         let (_, after_keys) = ctx.store.scan_job_keys(0, 200).await?;
         assert!(after_keys.len() > before_keys.len());
+        job_replay(
+            job.id.clone(),
+            config_path.clone(),
+            Some("manual-bare".to_string()),
+        )
+        .await?;
+        let manual_queue_size = ctx.store.queue_size("rrq:queue:manual-bare").await?;
+        assert!(manual_queue_size >= 1);
 
         let cancel_job = client
             .enqueue(

--- a/rrq-rs/orchestrator/src/commands/shared.rs
+++ b/rrq-rs/orchestrator/src/commands/shared.rs
@@ -1,15 +1,9 @@
 use std::collections::HashMap;
 
-use rrq::constants::QUEUE_KEY_PREFIX;
+use rrq_config::normalize_queue_name;
 
 pub(crate) fn queue_matches(filter: &str, job_queue: &str) -> bool {
-    if filter == job_queue {
-        return true;
-    }
-    if job_queue == format!("{}{}", QUEUE_KEY_PREFIX, filter) {
-        return true;
-    }
-    false
+    normalize_queue_name(filter) == normalize_queue_name(job_queue)
 }
 
 pub(crate) fn top_counts(map: &HashMap<String, usize>, limit: usize) -> Vec<(String, usize)> {
@@ -26,6 +20,7 @@ mod tests {
     fn queue_matches_accepts_exact_and_prefixed() {
         assert!(queue_matches("default", "default"));
         assert!(queue_matches("default", "rrq:queue:default"));
+        assert!(queue_matches("rrq:queue:default", "default"));
         assert!(!queue_matches("default", "other"));
     }
 

--- a/rrq-rs/producer/Cargo.toml
+++ b/rrq-rs/producer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrq-producer"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2024"
 license = "Apache-2.0"
 description = "RRQ producer client for enqueuing jobs into Redis."
@@ -25,7 +25,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["rt-multi-thread", "sync", "time"] }
 uuid = { version = "1.20.0", features = ["v4"] }
-rrq-config = { version = "0.9.16", path = "../config" }
+rrq-config = { version = "0.9.17", path = "../config" }
 
 [dev-dependencies]
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "time"] }

--- a/rrq-rs/protocol/Cargo.toml
+++ b/rrq-rs/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrq-protocol"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2024"
 license = "Apache-2.0"
 description = "Shared RRQ runner protocol types."

--- a/rrq-rs/runner/Cargo.toml
+++ b/rrq-rs/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rrq-runner"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2024"
 license = "Apache-2.0"
 description = "RRQ runner runtime for Rust."
@@ -13,7 +13,7 @@ categories = ["asynchronous"]
 
 [dependencies]
 async-trait = "0.1.89"
-rrq-protocol = { version = "0.9.16", path = "../protocol" }
+rrq-protocol = { version = "0.9.17", path = "../protocol" }
 chrono = "0.4.43"
 serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }

--- a/rrq-ts/package.json
+++ b/rrq-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrq-ts",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "RRQ TypeScript producer and runner runtime.",
   "license": "MIT",
   "author": "RRQ Contributors",


### PR DESCRIPTION
This PR enforces a single queue-name invariant in Rust: queue names are canonicalized to rrq:queue:<name> whether input is bare or fully-qualified.

###  Key updates:

  - Added shared Rust queue normalization helper (rrq-config).
  - Normalized queue fields during config load:
      - default_queue_name
      - runner_routes keys
  - Normalized enqueue and job metadata paths in orchestrator client.
  - Normalized worker queue setup, retry/orphan recovery queue targets, and route resolution.
  - Updated CLI flows (queue, job replay, dlq requeue) to normalize input and preserve canonical metadata.
  - Kept normalization Rust-only (Py/TS remain pass-through bindings).

###  Tests:

  - Added/updated Rust tests for config normalization, routing behavior, and metadata invariants.
  - Added/updated Py/TS integration tests asserting canonical queue metadata and prefixed pass-through behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core queue naming used by enqueueing, routing, retries, and CLI operations; while behavior is largely normalization, it could break deployments relying on previously-mixed bare vs prefixed keys or custom routing maps.
> 
> **Overview**
> **Queue names are now canonicalized in the Rust core** to always use the `rrq:queue:`-prefixed form, regardless of whether callers/config provide bare names or full Redis keys.
> 
> This introduces `rrq-config::normalize_queue_name`, applies it during config load (`default_queue_name`, `runner_routes`), and threads normalization through orchestrator enqueue, worker routing/retry/orphan recovery, and multiple CLI paths (queue commands, DLQ requeue, debug/stress, job replay) to keep stored job metadata and routing consistent.
> 
> Bindings and docs are updated to match: Python/TypeScript tests now assert canonical queue keys while ensuring already-prefixed names pass through unchanged; package versions bump to `0.9.17`, and README/config docs are refreshed to emphasize Rust-first architecture and binding behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09d81711a64ef4065a3f02fdf731f9dc8831a053. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->