### PR TITLE
Added additional telemetry and analytics hooks

### DIFF
--- a/docs/PARITY_SPEC.md
+++ b/docs/PARITY_SPEC.md
@@ -82,6 +82,7 @@ Runner spans must use:
   - `rrq.job_id`, `rrq.function`, `rrq.queue`, `rrq.attempt`, `rrq.worker_id`
   - `rrq.outcome`, `rrq.duration_ms`, `rrq.retry_delay_ms`
   - `rrq.error_message`, `rrq.error_type`
+  - optional timing attrs: `rrq.queue_wait_ms`, `rrq.deadline_remaining_ms`
 
 Trace propagation uses `trace_context` (string map) on the job payload. RRQ does
 not auto-inject producer trace context; callers must provide it explicitly.

--- a/rrq-rs/Cargo.lock
+++ b/rrq-rs/Cargo.lock
@@ -444,7 +444,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -463,12 +462,6 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -500,11 +493,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -1152,7 +1143,6 @@ dependencies = [
  "js-sys",
  "pin-project-lite",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -1184,7 +1174,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tonic",
- "tracing",
 ]
 
 [[package]]
@@ -1470,9 +1459,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "futures-channel",
  "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",

--- a/rrq-rs/orchestrator/Cargo.toml
+++ b/rrq-rs/orchestrator/Cargo.toml
@@ -35,9 +35,9 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter", "json"] }
 uuid = { version = "1.20.0", features = ["v4"] }
 rand = "0.9.2"
-opentelemetry = { version = "0.31.0", default-features = false, features = ["trace"] }
-opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["http-proto", "reqwest-client", "reqwest-rustls-webpki-roots", "trace"] }
-opentelemetry_sdk = { version = "0.31.0", default-features = false, features = ["trace", "rt-tokio", "experimental_trace_batch_span_processor_with_async_runtime"] }
+opentelemetry = { version = "0.31.0", default-features = false, features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["http-proto", "reqwest-client", "reqwest-rustls-webpki-roots", "trace", "metrics"] }
+opentelemetry_sdk = { version = "0.31.0", default-features = false, features = ["trace", "metrics", "rt-tokio", "experimental_trace_batch_span_processor_with_async_runtime"] }
 tracing-opentelemetry = "0.32.1"
 
 rrq-protocol = { version = "0.9.18", path = "../protocol" }

--- a/rrq-rs/orchestrator/src/telemetry.rs
+++ b/rrq-rs/orchestrator/src/telemetry.rs
@@ -2,11 +2,13 @@ use std::collections::HashMap;
 use std::env;
 use std::sync::OnceLock;
 
-use opentelemetry::KeyValue;
 use opentelemetry::global;
+use opentelemetry::metrics::{Counter, Histogram, Meter};
 use opentelemetry::propagation::{Extractor, TextMapCompositePropagator};
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry_otlp::{SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry::{KeyValue, Value};
+use opentelemetry_otlp::{MetricExporter, SpanExporter, WithExportConfig, WithHttpConfig};
+use opentelemetry_sdk::metrics as sdkmetrics;
 use opentelemetry_sdk::propagation::{BaggagePropagator, TraceContextPropagator};
 use opentelemetry_sdk::trace::span_processor_with_async_runtime::BatchSpanProcessor;
 use opentelemetry_sdk::{Resource, runtime, trace as sdktrace};
@@ -22,7 +24,40 @@ pub enum LogFormat {
 }
 
 static LOG_FORMAT: OnceLock<LogFormat> = OnceLock::new();
-static OTEL_PROVIDER: OnceLock<sdktrace::SdkTracerProvider> = OnceLock::new();
+static OTEL_TRACE_PROVIDER: OnceLock<sdktrace::SdkTracerProvider> = OnceLock::new();
+static OTEL_METRIC_PROVIDER: OnceLock<sdkmetrics::SdkMeterProvider> = OnceLock::new();
+static RRQ_METRICS: OnceLock<RrqMetrics> = OnceLock::new();
+
+#[derive(Clone)]
+struct ResourceMetadata {
+    service_name: String,
+    environment: Option<String>,
+    version: Option<String>,
+}
+
+struct RrqMetrics {
+    poll_cycles_total: Counter<u64>,
+    jobs_fetched_total: Counter<u64>,
+    lock_acquire_total: Counter<u64>,
+    jobs_processed_total: Counter<u64>,
+    job_duration_ms: Histogram<f64>,
+    queue_wait_ms: Histogram<f64>,
+    orphan_recovered_total: Counter<u64>,
+}
+
+impl RrqMetrics {
+    fn new(meter: &Meter) -> Self {
+        Self {
+            poll_cycles_total: meter.u64_counter("rrq_poll_cycles_total").build(),
+            jobs_fetched_total: meter.u64_counter("rrq_jobs_fetched_total").build(),
+            lock_acquire_total: meter.u64_counter("rrq_lock_acquire_total").build(),
+            jobs_processed_total: meter.u64_counter("rrq_jobs_processed_total").build(),
+            job_duration_ms: meter.f64_histogram("rrq_job_duration_ms").build(),
+            queue_wait_ms: meter.f64_histogram("rrq_queue_wait_ms").build(),
+            orphan_recovered_total: meter.u64_counter("rrq_orphan_recovered_total").build(),
+        }
+    }
+}
 
 pub fn log_format() -> LogFormat {
     *LOG_FORMAT.get_or_init(|| {
@@ -40,7 +75,9 @@ fn parse_log_format(value: &str) -> LogFormat {
 
 pub fn init_tracing() {
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    let (otel_layer, otel_error) = init_otel_layer();
+    let metadata = resolve_resource_metadata();
+    let (otel_layer, trace_error) = init_otel_layer(&metadata);
+    let metrics_error = init_metrics_provider(&metadata);
     match log_format() {
         LogFormat::Json => {
             if let Some(otel_layer) = otel_layer {
@@ -76,8 +113,11 @@ pub fn init_tracing() {
         }
     }
 
-    if let Some(error) = otel_error {
+    if let Some(error) = trace_error {
         tracing::warn!(error = %error, "OpenTelemetry tracing exporter failed to initialize");
+    }
+    if let Some(error) = metrics_error {
+        tracing::warn!(error = %error, "OpenTelemetry metrics exporter failed to initialize");
     }
 }
 
@@ -95,13 +135,41 @@ pub fn set_parent_from_trace_context(
     let _ = span.set_parent(parent);
 }
 
-fn init_otel_layer() -> (
+fn resolve_resource_metadata() -> ResourceMetadata {
+    let service_name = env_optional_nonempty("OTEL_SERVICE_NAME")
+        .or_else(|| otel_resource_attribute("service.name"))
+        .unwrap_or_else(|| "rrq".to_string());
+    ResourceMetadata {
+        service_name,
+        environment: otel_resource_attribute("deployment.environment"),
+        version: otel_resource_attribute("service.version"),
+    }
+}
+
+fn build_resource(metadata: &ResourceMetadata) -> Resource {
+    let mut resource_builder = Resource::builder().with_service_name(metadata.service_name.clone());
+    if let Some(environment) = metadata.environment.as_deref() {
+        resource_builder = resource_builder.with_attribute(KeyValue::new(
+            "deployment.environment",
+            environment.to_string(),
+        ));
+    }
+    if let Some(version) = metadata.version.as_deref() {
+        resource_builder =
+            resource_builder.with_attribute(KeyValue::new("service.version", version.to_string()));
+    }
+    resource_builder.build()
+}
+
+fn init_otel_layer(
+    metadata: &ResourceMetadata,
+) -> (
     Option<
         tracing_opentelemetry::OpenTelemetryLayer<tracing_subscriber::Registry, sdktrace::Tracer>,
     >,
     Option<String>,
 ) {
-    if !otel_enabled() {
+    if !otel_trace_enabled() {
         return (None, None);
     }
 
@@ -110,40 +178,48 @@ fn init_otel_layer() -> (
         Box::new(BaggagePropagator::new()),
     ]));
 
-    let service_name = env_optional_nonempty("OTEL_SERVICE_NAME")
-        .or_else(|| otel_resource_attribute("service.name"))
-        .unwrap_or_else(|| "rrq".to_string());
-    let environment = otel_resource_attribute("deployment.environment");
-    let version = otel_resource_attribute("service.version");
-
-    let exporter = match build_otlp_exporter() {
+    let exporter = match build_otlp_span_exporter() {
         Ok(exporter) => exporter,
         Err(err) => return (None, Some(err)),
     };
 
-    let mut resource_builder = Resource::builder().with_service_name(service_name.clone());
-    if let Some(environment) = environment {
-        resource_builder =
-            resource_builder.with_attribute(KeyValue::new("deployment.environment", environment));
-    }
-    if let Some(version) = version {
-        resource_builder =
-            resource_builder.with_attribute(KeyValue::new("service.version", version));
-    }
-    let resource = resource_builder.build();
+    let resource = build_resource(metadata);
 
     let provider = sdktrace::SdkTracerProvider::builder()
         .with_resource(resource)
         .with_span_processor(BatchSpanProcessor::builder(exporter, runtime::Tokio).build())
         .build();
-    let tracer = provider.tracer(service_name);
-    let _ = OTEL_PROVIDER.set(provider);
+    let tracer = provider.tracer(metadata.service_name.clone());
+    let _ = OTEL_TRACE_PROVIDER.set(provider);
 
     let layer = tracing_opentelemetry::layer().with_tracer(tracer);
     (Some(layer), None)
 }
 
-fn otel_enabled() -> bool {
+fn init_metrics_provider(metadata: &ResourceMetadata) -> Option<String> {
+    if !otel_metrics_enabled() {
+        return None;
+    }
+
+    let exporter = match build_otlp_metric_exporter() {
+        Ok(exporter) => exporter,
+        Err(err) => return Some(err),
+    };
+
+    let meter_provider = sdkmetrics::SdkMeterProvider::builder()
+        .with_resource(build_resource(metadata))
+        .with_periodic_exporter(exporter)
+        .build();
+    global::set_meter_provider(meter_provider.clone());
+
+    let meter = global::meter("rrq.orchestrator");
+    let _ = RRQ_METRICS.set(RrqMetrics::new(&meter));
+    let _ = OTEL_METRIC_PROVIDER.set(meter_provider);
+
+    None
+}
+
+fn otel_trace_enabled() -> bool {
     if let Ok(endpoint) = env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
         && !endpoint.is_empty()
     {
@@ -157,10 +233,23 @@ fn otel_enabled() -> bool {
     false
 }
 
-fn build_otlp_exporter() -> Result<SpanExporter, String> {
-    let endpoint = resolve_otlp_endpoint();
+fn otel_metrics_enabled() -> bool {
+    if let Ok(endpoint) = env::var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
+        && !endpoint.is_empty()
+    {
+        return true;
+    }
+    if let Ok(endpoint) = env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        && !endpoint.is_empty()
+    {
+        return true;
+    }
+    false
+}
 
-    let headers = parse_otlp_headers(env::var("OTEL_EXPORTER_OTLP_HEADERS").ok());
+fn build_otlp_span_exporter() -> Result<SpanExporter, String> {
+    let endpoint = resolve_otlp_trace_endpoint();
+    let headers = resolve_otlp_headers("OTEL_EXPORTER_OTLP_TRACES_HEADERS");
 
     let mut exporter_builder = SpanExporter::builder().with_http().with_endpoint(endpoint);
     if !headers.is_empty() {
@@ -169,7 +258,28 @@ fn build_otlp_exporter() -> Result<SpanExporter, String> {
     exporter_builder.build().map_err(|err| err.to_string())
 }
 
-fn resolve_otlp_endpoint() -> String {
+fn build_otlp_metric_exporter() -> Result<MetricExporter, String> {
+    let endpoint = resolve_otlp_metrics_endpoint();
+    let headers = resolve_otlp_headers("OTEL_EXPORTER_OTLP_METRICS_HEADERS");
+
+    let mut exporter_builder = MetricExporter::builder()
+        .with_http()
+        .with_endpoint(endpoint);
+    if !headers.is_empty() {
+        exporter_builder = exporter_builder.with_headers(headers);
+    }
+    exporter_builder.build().map_err(|err| err.to_string())
+}
+
+fn resolve_otlp_headers(signal_specific_header_env: &str) -> HashMap<String, String> {
+    let mut headers = parse_otlp_headers(env::var("OTEL_EXPORTER_OTLP_HEADERS").ok());
+    for (key, value) in parse_otlp_headers(env::var(signal_specific_header_env).ok()) {
+        headers.insert(key, value);
+    }
+    headers
+}
+
+fn resolve_otlp_trace_endpoint() -> String {
     if let Ok(endpoint) = env::var("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")
         && !endpoint.is_empty()
     {
@@ -179,18 +289,58 @@ fn resolve_otlp_endpoint() -> String {
     if let Ok(endpoint) = env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
         && !endpoint.is_empty()
     {
-        return ensure_traces_path(endpoint);
+        return ensure_signal_path(endpoint, "traces");
     }
 
     "http://127.0.0.1:4318/v1/traces".to_string()
 }
 
-fn ensure_traces_path(endpoint: String) -> String {
-    if endpoint.ends_with("/v1/traces") {
+fn resolve_otlp_metrics_endpoint() -> String {
+    if let Ok(endpoint) = env::var("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")
+        && !endpoint.is_empty()
+    {
         return endpoint;
     }
-    let base = endpoint.trim_end_matches('/');
-    format!("{base}/v1/traces")
+
+    if let Ok(endpoint) = env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        && !endpoint.is_empty()
+    {
+        return ensure_signal_path(endpoint, "metrics");
+    }
+
+    "http://127.0.0.1:4318/v1/metrics".to_string()
+}
+
+fn ensure_signal_path(endpoint: String, signal: &str) -> String {
+    let expected_suffix = format!("/v1/{signal}");
+    let (endpoint_path, endpoint_suffix) = split_endpoint_suffix(&endpoint);
+    let endpoint_path = endpoint_path.trim_end_matches('/');
+
+    if endpoint_path.ends_with(&expected_suffix) {
+        return format!("{endpoint_path}{endpoint_suffix}");
+    }
+
+    let base = strip_otlp_signal_suffix(endpoint_path);
+    format!("{base}{expected_suffix}{endpoint_suffix}")
+}
+
+fn split_endpoint_suffix(endpoint: &str) -> (&str, &str) {
+    let split_index = endpoint
+        .find('?')
+        .into_iter()
+        .chain(endpoint.find('#'))
+        .min()
+        .unwrap_or(endpoint.len());
+    endpoint.split_at(split_index)
+}
+
+fn strip_otlp_signal_suffix(endpoint: &str) -> &str {
+    for suffix in ["/v1/traces", "/v1/metrics", "/v1/logs"] {
+        if let Some(base) = endpoint.strip_suffix(suffix) {
+            return base;
+        }
+    }
+    endpoint
 }
 
 fn env_optional_nonempty(key: &str) -> Option<String> {
@@ -239,6 +389,98 @@ fn parse_otlp_headers(raw: Option<String>) -> HashMap<String, String> {
     headers
 }
 
+fn add_counter(counter: &Counter<u64>, value: u64, attrs: &[(&str, Value)]) {
+    let attrs: Vec<KeyValue> = attrs
+        .iter()
+        .map(|(key, value)| KeyValue::new((*key).to_string(), value.clone()))
+        .collect();
+    counter.add(value, &attrs);
+}
+
+fn record_histogram(histogram: &Histogram<f64>, value: f64, attrs: &[(&str, Value)]) {
+    if !value.is_finite() || value < 0.0 {
+        return;
+    }
+    let attrs: Vec<KeyValue> = attrs
+        .iter()
+        .map(|(key, value)| KeyValue::new((*key).to_string(), value.clone()))
+        .collect();
+    histogram.record(value, &attrs);
+}
+
+pub fn record_poll_cycle(result: &str) {
+    let Some(metrics) = RRQ_METRICS.get() else {
+        return;
+    };
+    add_counter(
+        &metrics.poll_cycles_total,
+        1,
+        &[("result", Value::from(result.to_string()))],
+    );
+}
+
+pub fn record_jobs_fetched(queue: &str, fetched: u64) {
+    if fetched == 0 {
+        return;
+    }
+    let Some(metrics) = RRQ_METRICS.get() else {
+        return;
+    };
+    add_counter(
+        &metrics.jobs_fetched_total,
+        fetched,
+        &[("queue", Value::from(queue.to_string()))],
+    );
+}
+
+pub fn record_lock_acquire(queue: &str, result: &str) {
+    let Some(metrics) = RRQ_METRICS.get() else {
+        return;
+    };
+    add_counter(
+        &metrics.lock_acquire_total,
+        1,
+        &[
+            ("queue", Value::from(queue.to_string())),
+            ("result", Value::from(result.to_string())),
+        ],
+    );
+}
+
+pub fn record_queue_wait_ms(queue: &str, queue_wait_ms: f64) {
+    let Some(metrics) = RRQ_METRICS.get() else {
+        return;
+    };
+    record_histogram(
+        &metrics.queue_wait_ms,
+        queue_wait_ms,
+        &[("queue", Value::from(queue.to_string()))],
+    );
+}
+
+pub fn record_job_processed(queue: &str, runner: &str, outcome: &str, duration_ms: f64) {
+    let Some(metrics) = RRQ_METRICS.get() else {
+        return;
+    };
+    let attrs = [
+        ("queue", Value::from(queue.to_string())),
+        ("runner", Value::from(runner.to_string())),
+        ("outcome", Value::from(outcome.to_string())),
+    ];
+    add_counter(&metrics.jobs_processed_total, 1, &attrs);
+    record_histogram(&metrics.job_duration_ms, duration_ms, &attrs);
+}
+
+pub fn record_orphan_recovered(count: u64) {
+    if count == 0 {
+        return;
+    }
+    let Some(metrics) = RRQ_METRICS.get() else {
+        return;
+    };
+    metrics.orphan_recovered_total.add(count, &[]);
+}
+
 struct HashMapExtractor<'a>(&'a HashMap<String, String>);
 
 impl<'a> Extractor for HashMapExtractor<'a> {
@@ -282,5 +524,32 @@ mod tests {
     fn parse_otlp_headers_skips_invalid_pairs() {
         let headers = parse_otlp_headers(Some("=,onlykey, k= , =v".to_string()));
         assert!(headers.is_empty());
+    }
+
+    #[test]
+    fn ensure_signal_path_appends_v1_signal() {
+        assert_eq!(
+            ensure_signal_path("http://collector:4318".to_string(), "metrics"),
+            "http://collector:4318/v1/metrics"
+        );
+        assert_eq!(
+            ensure_signal_path("http://collector:4318/v1/traces".to_string(), "traces"),
+            "http://collector:4318/v1/traces"
+        );
+    }
+
+    #[test]
+    fn ensure_signal_path_replaces_existing_signal_suffix() {
+        assert_eq!(
+            ensure_signal_path("http://collector:4318/v1/traces".to_string(), "metrics"),
+            "http://collector:4318/v1/metrics"
+        );
+        assert_eq!(
+            ensure_signal_path(
+                "http://collector:4318/v1/metrics?token=abc".to_string(),
+                "traces"
+            ),
+            "http://collector:4318/v1/traces?token=abc"
+        );
     }
 }

--- a/rrq-rs/runner/Cargo.toml
+++ b/rrq-rs/runner/Cargo.toml
@@ -19,9 +19,9 @@ serde_json = "1.0.149"
 tokio = { version = "1.49.0", features = ["fs", "io-util", "macros", "net", "rt-multi-thread", "sync", "time"] }
 tracing = "0.1.44"
 
-opentelemetry = { version = "0.31.0", optional = true, features = ["trace"] }
-opentelemetry-otlp = { version = "0.31.0", optional = true, features = ["grpc-tonic"] }
-opentelemetry_sdk = { version = "0.31.0", optional = true, features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.31.0", optional = true, default-features = false, features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.31.0", optional = true, default-features = false, features = ["grpc-tonic", "trace", "metrics"] }
+opentelemetry_sdk = { version = "0.31.0", optional = true, default-features = false, features = ["rt-tokio", "trace", "metrics"] }
 tracing-opentelemetry = { version = "0.32.1", optional = true }
 tracing-subscriber = { version = "0.3.22", optional = true, features = ["env-filter", "fmt", "registry"] }
 

--- a/rrq-ts/src/otel.ts
+++ b/rrq-ts/src/otel.ts
@@ -94,6 +94,10 @@ export class OtelTelemetry implements Telemetry {
     if (request.context.worker_id) {
       attributes["rrq.worker_id"] = request.context.worker_id;
     }
+    const enqueueMs = Date.parse(request.context.enqueue_time);
+    if (!Number.isNaN(enqueueMs)) {
+      attributes["rrq.queue_wait_ms"] = Math.max(Date.now() - enqueueMs, 0);
+    }
     const span = tracer.startSpan(
       "rrq.runner",
       {
@@ -104,6 +108,10 @@ export class OtelTelemetry implements Telemetry {
     );
     if (request.context.deadline) {
       span.setAttribute("rrq.deadline", request.context.deadline);
+      const deadlineMs = Date.parse(request.context.deadline);
+      if (!Number.isNaN(deadlineMs)) {
+        span.setAttribute("rrq.deadline_remaining_ms", Math.max(deadlineMs - Date.now(), 0));
+      }
     }
     return new OtelRunnerSpan(span);
   }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches orchestrator/runner execution paths to add spans and metrics hooks and changes OTLP exporter configuration resolution; behavior should be unchanged, but telemetry code runs on hot paths and could impact performance or observability config if misconfigured.
> 
> **Overview**
> Adds *additional OpenTelemetry telemetry* across RRQ.
> 
> Runner integrations (Python, TypeScript, Rust) now emit optional timing attributes `rrq.queue_wait_ms` and `rrq.deadline_remaining_ms` (including timezone-safe deadline handling in Python), and docs/spec are updated to codify these attributes.
> 
> The Rust orchestrator gains new internal lifecycle spans (`rrq.poll_cycle`, `rrq.fetch_queue`, `rrq.dispatch`) and OTLP *metrics* export support, recording counters/histograms for polling, fetch/lock outcomes, queue wait, job duration/outcomes, and orphan recovery; the Rust runner similarly adds OTLP metrics (in-flight, channel pressure, deadline expired, cancellations) and wires metrics hooks into request handling/cancellation/deadline codepaths. Dependency configs are updated to enable OpenTelemetry `metrics` features and endpoint/header resolution is expanded per-signal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45806eb0668f23b31dc030f44f0f12c05ae9f7ee. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->